### PR TITLE
tweaks needed for libtas

### DIFF
--- a/src/org/recompile/freej2me/Anbu.java
+++ b/src/org/recompile/freej2me/Anbu.java
@@ -256,15 +256,7 @@ public class Anbu
 			// Create a renderer, and a texture where drawing can take place, streaming for constant updates.
 			renderer = SDL_CreateRenderer(window, -1, 0);
 			texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, lcdWidth, lcdHeight);
-			pixels = new Memory(lcdWidth * lcdHeight * 4); 
-
-			/* 
-			 * Input reading should not be tied to the render logic, otherwise jars that only send new render data 
-			 * after an input is registered (Ex: JBenchmark 2 and some other jars that use Form UI) will get softlocked.
-			 */
-			keytimer = new Timer();
-			keytask = new TimerTask() {	public void run() { processEvents(); } };
-			keytimer.schedule(keytask, 0, 1);
+			pixels = new Memory(lcdWidth * lcdHeight * 4);
 
 			SDL_JoystickEventState(SDL_ENABLE);
 
@@ -279,6 +271,13 @@ public class Anbu
 
 		public void paint()
 		{
+			/* 
+			 * Normally, input reading should not be tied to the render logic, because that would softlock jars that only
+			 * send new render data after an input is registered (Ex: JBenchmark 2 and some other jars that use Form UI).
+			 * But for determinism in libTAS, inputs must be pulled synchronously with rendering, because libTAS processes
+			 * inputs (and a lot of other things) during frame boundaries, which is when the program calls its render function.
+			 */
+			processEvents();
 
 			/* 
 			 * Let's make resolution changes and adjust any relevant objects here, as it's right on the render path 


### PR DESCRIPTION
Looks like there's a little conflict between regular j2me apps (and tests?) and libTAS functionality. Without these tweaks freej2me-plus won't run in libTAS, because it needs input and rendering to be connected apparently.

I'm not sure how to solve it nicely, so I'm basically opening this as a discussion, but at the very least we did verify that it runs really well in libTAS with these changes: 20fps, no audio issues in the encode (there has to be no FPS cap set, otherwise things are slow and unreliable). Loading a savestate currently crashes, but this is probably a future topic.

https://github.com/user-attachments/assets/a5bf9e3a-5879-40c2-a87e-361331466903

Pinging @clementgallet whose fix I'm applying here.