### PR TITLE
enable star key on sdl2

### DIFF
--- a/src/org/recompile/freej2me/Anbu.java
+++ b/src/org/recompile/freej2me/Anbu.java
@@ -562,6 +562,7 @@ public class Anbu
 			if(keycode == SDLK_KP_1) return Mobile.KEY_NUM7; // B
 			if(keycode == SDLK_KP_3) return Mobile.KEY_NUM9; // X
 			if(keycode == SDLK_X) return Mobile.KEY_POUND; // Y
+			if(keycode == SDLK_Z) return Mobile.KEY_STAR; // ???
 
 			
 			if(keycode == SDLK_C) return Mobile.KEY_NUM0; // Home


### PR DESCRIPTION
Unsure if it needs to be enabled in other places, but at least it started working for me, and a bunch of games use it.

No idea what's up with whitespace changes, I'm not seeing them on my end.