### PR TITLE
Fix to handle loading kjx on Windows filesystem

### DIFF
--- a/src/org/recompile/mobile/MobilePlatform.java
+++ b/src/org/recompile/mobile/MobilePlatform.java
@@ -537,9 +537,7 @@ public class MobilePlatform
 				}
 
 				// Send dumped jar path to loader
-				fileName = "file:" + tmpfile.getAbsolutePath().replace("./", "");
-
-				URL jar = new URL(fileName);
+				URL jar = tmpfile.toURI().toURL();
 				loader = new MIDletLoader(jar, descriptorProperties);
 
 				if(Mobile.deleteTemporaryKJXFiles) 


### PR DESCRIPTION

I found  a bug on loading kjx file in case `tmpfile.getAbsolutePath()` returns path string in Windows format (like `C:/kjx/something.kjx` ).

To handle the problem, I modified code for getting URL.

Could you review this?
