### PR TITLE
Fix: setCurrent is not called before calling paint

### DIFF
--- a/src/javax/microedition/lcdui/Canvas.java
+++ b/src/javax/microedition/lcdui/Canvas.java
@@ -157,7 +157,10 @@ public abstract class Canvas extends Displayable
 				Mobile.getDisplay().postPaintRequest(() -> { repaintRequest(x, y, width, height); }); 
 			}
 		}
-		else { repaintRequest(x, y, width, height); }
+		else {
+			Mobile.getDisplay().processPaintsNow();
+			repaintRequest(x, y, width, height); 
+		}
 	}
 
 	public void repaintRequest(int x, int y, int width, int height) 


### PR DESCRIPTION

Hi, I'm a fan of legacy J2ME game in Japan. Currently, I implement some features for playing kjx in freej2me.

Thanks a lot for implementing immediate repaint configuration. a298580417e133e0ea89380786eda8c69f16f9f2

In case I enabled compatImmediateRepaints, I found issue on playing games.
I guess it is caused by calling paint method before calling `Display.setCurrent`.

By forcing calling `Display.processPaintsNow()` before `repaintRequest()` to ensure `Display.setCurrent()` before `paint()`, I found some games became playable.
How about this fix? 