### PR TITLE
Fix: To handle number key, improve code of updating keystate

### DIFF
--- a/src/org/recompile/mobile/MobilePlatform.java
+++ b/src/org/recompile/mobile/MobilePlatform.java
@@ -187,7 +187,7 @@ public class MobilePlatform
 		else if (!isPaused)
 		{
 			updateKeyState(Mobile.getGameAction(keycode), true);
-			updateVodafoneKeyState(Mobile.getGameAction(keycode), true);
+			updateVodafoneKeyState(Mobile.getCanvasAction(keycode), true);
 			updateDoJaKeyState(Mobile.getGameAction(keycode), true);
 			if (!Mobile.isDoJa && Mobile.getDisplay() != null && (displayable = Mobile.getDisplay().getCurrent()) != null) 
 			{ 
@@ -202,7 +202,7 @@ public class MobilePlatform
 		if(!isPaused && MIDletLoader.MIDletSelected) 
 		{
 			updateKeyState(Mobile.getGameAction(keycode), false);
-			updateVodafoneKeyState(Mobile.getGameAction(keycode), false);
+			updateVodafoneKeyState(Mobile.getCanvasAction(keycode), false);
 			updateDoJaKeyState(Mobile.getGameAction(keycode), false);
 			if (!Mobile.isDoJa && Mobile.getDisplay() != null && (displayable = Mobile.getDisplay().getCurrent()) != null && MIDletLoader.MIDletSelected) { displayable.keyReleased(keycode); }
 		}
@@ -280,13 +280,13 @@ public class MobilePlatform
 			case Canvas.KEY_NUM0:
 				mask = 1; //  0 0
 				break;
-			case Canvas.GAME_A:
+			case Canvas.KEY_NUM1:
 				mask = 1 << 1; //  1 1
 				break;
 			case Canvas.KEY_NUM2:
 				mask = 1 << 2; //  2 2
 				break;
-			case Canvas.GAME_B:
+			case Canvas.KEY_NUM3:
 				mask = 1 << 3; //  3 3
 				break;
 			case Canvas.KEY_NUM4:
@@ -298,13 +298,13 @@ public class MobilePlatform
 			case Canvas.KEY_NUM6:
 				mask = 1 << 6; //  6 6
 				break;
-			case Canvas.GAME_C:
+			case Canvas.KEY_NUM7:
 				mask = 1 << 7; //  7 7
 				break;
 			case Canvas.KEY_NUM8:
 				mask = 1 << 8; //  8 8
 				break;
-			case Canvas.GAME_D:
+			case Canvas.KEY_NUM9:
 				mask = 1 << 9; //  9 9
 				break;
 			case Canvas.KEY_STAR:


### PR DESCRIPTION
Fix #104 

On previous implementation, `Mobile.getGameAction()` is used to convert keycode to keyevent. Since the function converts some number keys (ex: 2, 4, 6, 8) to directional key (ex: up, left, right, down), these number keys are not revealed on keystate.

To fix the problem, I implement to use `Mobile.getCanvasAction` instead of `Mobile.getGameAction()`.

Could you review this?