### PR TITLE
Fix: Garbled characters issue in config path

### DIFF
--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -100,8 +100,13 @@ public class Config
 
 	public void init(String appname)
 	{
-		configPath = Mobile.getPlatform().dataPath + "./config/"+appname;
-		configFile = configPath + "/game.conf";
+        try
+        {
+            // For ISO-8859-1 encodings, we'll use UTF-8 for save paths, helps with chinese and special characters (Mirror RecordStore.java)
+            configPath = new String((Mobile.getPlatform().dataPath + "./config/" + appname).getBytes(System.getProperty("file.encoding")), System.getProperty("file.encoding").equals(Mobile.supportedEncodings[Mobile.ISO_8859_1]) ? "UTF-8" : Mobile.textEncoding);
+			configFile = configPath + "/game.conf";
+        }
+        catch (UnsupportedEncodingException e) { }
 		// Load Config //
 		try
 		{

--- a/src/org/recompile/freej2me/Config.java
+++ b/src/org/recompile/freej2me/Config.java
@@ -28,6 +28,7 @@ import java.io.FileReader;
 import java.io.FileOutputStream;
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 
 import javax.microedition.media.Manager;
 
@@ -578,3 +579,4 @@ public class Config
 	}
 
 }
+

--- a/src/org/recompile/mobile/MobilePlatform.java
+++ b/src/org/recompile/mobile/MobilePlatform.java
@@ -696,6 +696,11 @@ public class MobilePlatform
 				// Send dumped jar path to loader
 				URL jar = tmpfile.toURI().toURL();
 				loader = new MIDletLoader(jar, descriptorProperties);
+				if (Mobile.isDoJa)
+				{
+					Mobile.textEncoding = "Shift_JIS";
+					MobilePlatform.checkFileEncoding();
+				}
 				Mobile.config.init(loader.suitename);
 				
 				return true;
@@ -804,6 +809,11 @@ public class MobilePlatform
 			{
 				URL jar = new URL(fileName);
 				loader = new MIDletLoader(jar, descriptorProperties);
+				if (Mobile.isDoJa)
+				{
+					Mobile.textEncoding = Mobile.supportedEncodings[Mobile.SHIFT_JIS];
+					MobilePlatform.checkFileEncoding();
+				}
 				Mobile.config.init(loader.suitename);
 
 				return true;


### PR DESCRIPTION
Mirrored the same logic from RecordStore.java to ensure game name folders under the config path do not have garbled characters when containing CJK characters.