### PR TITLE
Upgrade Java version to 1.8 in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,8 +5,8 @@
 *    Class compilation
 ****************************************************
 -->
-	<property name="source.version" value="1.6"/>
-	<property name="target.version" value="1.6"/>
+	<property name="source.version" value="1.8"/>
+	<property name="target.version" value="1.8"/>
 
 	<mkdir dir="build/classes"/>
 	<mkdir dir="build/classes/org/objectweb"/>
@@ -75,3 +75,4 @@
 	</jar>
 
 </project>
+


### PR DESCRIPTION
Updated Java source and target versions from 1.6 to 1.8 in build.xml. Adjusted class compilation and JAR building configurations accordingly.Modern ANT compilers no longer fully support 1.6 and are problematic.But when they say 8 is mostly used, I mean version 1.8.