### PR TITLE
fix: respect RetroArch fast-forward rate

### DIFF
--- a/src/javax/microedition/lcdui/StringItem.java
+++ b/src/javax/microedition/lcdui/StringItem.java
@@ -74,14 +74,14 @@ public class StringItem extends Item
 		{
 			height = Font.getDefaultFont().getHeight() + 2*buttonMargin + 2*buttonPadding;
 		} 
-		else if (height == 0 && !text.isEmpty()) 
+		else if (height == 0 && text != null && !text.isEmpty()) 
 		{
 			lines = wrapText(text, width, Font.getDefaultFont());
 			lineSpacing = 1;
 
 			height = lines.size() > 0 ? (lines.size()*Font.getDefaultFont().getHeight() + (lines.size()-1)*lineSpacing) : 0;
 		} 
-		else if (text.isEmpty() && lines == null) { lines = new ArrayList<String>(); }
+		else if ((text == null || text.isEmpty()) && lines == null) { lines = new ArrayList<String>(); }
 
 		return height;
 	}
@@ -117,7 +117,7 @@ public class StringItem extends Item
 
 	protected void renderItem(Graphics graphics, int x, int y, int width, int height) 
 	{
-		if (appearance == Item.BUTTON) 
+		if (appearance == Item.BUTTON)
 		{
 			graphics.setColor(Mobile.lcduiBGColor);
 			graphics.fillRect(x+buttonMargin, y+buttonMargin, width-2*buttonMargin, height-2*buttonMargin);
@@ -128,7 +128,7 @@ public class StringItem extends Item
 			graphics.setColor(Mobile.lcduiTextColor);
 			graphics.drawString(text, x+buttonMargin+buttonPadding, y+buttonMargin+buttonPadding, 0);
 		} 
-		else 
+		else
 		{
 			graphics.setColor(Mobile.lcduiTextColor);
 			for(int l=0;l<lines.size();l++) 

--- a/src/libretro/freej2me_libretro.c
+++ b/src/libretro/freej2me_libretro.c
@@ -152,6 +152,8 @@ bool frameRequested = false;
 bool fast_forwarding = false;
 int framesDropped = 0;
 
+float normal_throttle_rate = DEFAULT_FPS;
+
 /* Libretro exposed config variables START */
 
 char *options_update; /* String containing the options updated in check_variables() */
@@ -328,10 +330,32 @@ int freej2me_present(const char *path)
 // Fast-forward state tracker
 void check_fast_forwarding(void) 
 {
+	unsigned int multiplier_scaled = 0;
+
     if (Environ(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &fast_forwarding)) 
 	{
         javaRequestFrame[4] = fast_forwarding ? 1 : 0;
     }
+
+	struct retro_throttle_state throttle_state;
+	if (Environ(RETRO_ENVIRONMENT_GET_THROTTLE_STATE, &throttle_state))
+	{
+		if (throttle_state.mode == RETRO_THROTTLE_NONE && throttle_state.rate > 0.0f)
+		{
+			normal_throttle_rate = throttle_state.rate;
+		}
+
+		if (throttle_state.rate > 0.0f && normal_throttle_rate > 0.0f)
+		{
+			float multiplier = throttle_state.rate / normal_throttle_rate;
+			if (multiplier < 0.0f) { multiplier = 0.0f; }
+			if (multiplier > 655.35f) { multiplier = 655.35f; }
+			multiplier_scaled = (unsigned int)(multiplier * 100.0f + 0.5f);
+		}
+	}
+
+	javaRequestFrame[1] = (multiplier_scaled >> 8) & 0xFF;
+	javaRequestFrame[2] = (multiplier_scaled) & 0xFF;
 }
 
 /* Function to check the core's config states in the libretro frontend */

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -574,6 +574,8 @@ public class Libretro
 								case 15:
 									lastCoreUpdateTime = System.currentTimeMillis();
 
+									int multiplierScaled = (din[1] << 8) | din[2];
+
 									if(din[3] == 1) // Frontend has processed the last sent frame, start counting for pause
 									{
 										canPause = true;
@@ -589,8 +591,16 @@ public class Libretro
 									}
 
 									// Check if the frontend is fast-forwarding
-									if(din[4] == 0) { MobilePlatform.pressedKeys[20] = false; }
-									else { MobilePlatform.pressedKeys[20] = true; }
+									if(din[4] == 0)
+									{
+										MobilePlatform.pressedKeys[20] = false;
+									}
+									else
+									{
+										MobilePlatform.pressedKeys[20] = true;
+										if(multiplierScaled <= 0) { Mobile.fastForwardMultiplier = 20.0f; }
+										else { Mobile.fastForwardMultiplier = multiplierScaled / 100.0f; }
+									}
 
 									/* Send Frame to Libretro */
 									try

--- a/src/org/recompile/mobile/MIDletEnhancements.java
+++ b/src/org/recompile/mobile/MIDletEnhancements.java
@@ -46,7 +46,12 @@ public class MIDletEnhancements
         long now = System.currentTimeMillis();
         long elapsedMillis = now - lastMillisTime;
 
-        if (MobilePlatform.pressedKeys[20]) { curTimeMillis.addAndGet(elapsedMillis * 20); } 
+        if (MobilePlatform.pressedKeys[20])
+        {
+            float multiplier = Mobile.fastForwardMultiplier;
+            if (multiplier <= 0.0f) { multiplier = 20.0f; }
+            curTimeMillis.addAndGet((long) (elapsedMillis * multiplier));
+        }
         else if (Mobile.unlockFramerateHack > 2) { curTimeMillis.addAndGet((long) (elapsedMillis * (Mobile.limitFPS == 0 ? 20 : (float) Mobile.limitFPS / 10f))); } 
         else { curTimeMillis.addAndGet(elapsedMillis); }
 
@@ -59,7 +64,12 @@ public class MIDletEnhancements
         long now = System.nanoTime();
         long elapsedNanos = now - lastNanoTime;
 
-        if (MobilePlatform.pressedKeys[20]) { curNanoTime.addAndGet(elapsedNanos * 20); } 
+        if (MobilePlatform.pressedKeys[20])
+        {
+            float multiplier = Mobile.fastForwardMultiplier;
+            if (multiplier <= 0.0f) { multiplier = 20.0f; }
+            curNanoTime.addAndGet((long) (elapsedNanos * multiplier));
+        }
         else if (Mobile.unlockFramerateHack > 2) { curNanoTime.addAndGet((long) (elapsedNanos * (Mobile.limitFPS == 0 ? 20 : (float) Mobile.limitFPS / 10f))); } 
         else { curNanoTime.addAndGet(elapsedNanos); }
 

--- a/src/org/recompile/mobile/Mobile.java
+++ b/src/org/recompile/mobile/Mobile.java
@@ -192,6 +192,7 @@ public class Mobile
 	// Libretro flags
 	public static boolean isFastForwarding = false;
 	public static boolean isPaused = false;
+	public static volatile float fastForwardMultiplier = 20.0f;
 	public static byte libretroRestartRequested = 0; // Set when FreeJ2ME has to be restarted in some way (often to change character encoding)
 	public static byte libretroEncodingRequested = 0; // Encoding FreeJ2ME requested to be re-opened with (check the restartApp() method below)
 


### PR DESCRIPTION
This makes the libretro build respect RetroArch's fast-forward speed setting instead of always using the legacy 20x time scaling.
 
- The core reads the frontend throttle state via `RETRO_ENVIRONMENT_GET_THROTTLE_STATE`.
- A fast-forward multiplier is derived relative to the normal throttle rate and sent to the Java side as a scaled integer (x100) through `javaRequestFrame[1..2]`.
- The Java libretro handler (frame request, `din[0] == 15`) decodes the value and updates `Mobile.fastForwardMultiplier`.
- [MIDletEnhancements](cci:2://file:///c:/msys64/home/Magstic/freej2me-plus_dev/src/org/recompile/mobile/MIDletEnhancements.java:20:0-84:1) now uses `Mobile.fastForwardMultiplier` for time scaling during fast-forward (fallback to 20x when the multiplier is unavailable).
 
Note: When RetroArch fast-forward rate is set to 0 (uncapped), core falls back to the 20x.

---

It works well on both Windows 11 and Ubuntu (VM).

The AWT is still 20x; I didn't rashly modify it.