### PR TITLE
Fix: DoJa FastMath atan2 coordinate semantics

### DIFF
--- a/src/com/nttdocomo/ui/util3d/FastMath.java
+++ b/src/com/nttdocomo/ui/util3d/FastMath.java
@@ -92,8 +92,13 @@ public class FastMath
 
     public static float atan2(float a, float b) 
     {
-        if (Float.isNaN(a) || Float.isNaN(b)) { throw new IllegalArgumentException("Values must be finite."); }
-        return (float) Math.toDegrees(Math.atan2(a, b));
+        if (Float.isNaN(a) || Float.isNaN(b) || Float.isInfinite(a) || Float.isInfinite(b)) { throw new IllegalArgumentException("Values must be finite."); }
+        if (a == 0 && b == 0) { return Float.NaN; }
+        if (a == 0) { return 90.0f; }
+        if (b == 0) { return 0.0f; }
+
+        float angle = (float) Math.toDegrees(Math.atan2(b, a));
+        return angle < 0 ? angle + 180.0f : angle;
     }
 
     public static int floatToInnerInt(float v) 


### PR DESCRIPTION
Align FastMath.atan2 with the DoJa util3d documentation:

1. treating its arguments as x/y coordinates instead of Java's y/x atan2 order.

2. Preserve the zero-input edge cases so games that derive aim angles from FastMath.atan2 no longer offset their shots.

About game: Touhou Shinmadan

<img width="1156" height="659" alt="image" src="https://github.com/user-attachments/assets/e4e595b2-a2ca-4431-a8d7-0cdd792a75e6" />
