### PR TITLE
M3G: implement Sprite3D and fix multiple software renderer defects

### DIFF
--- a/src/javax/microedition/m3g/Graphics3D.java
+++ b/src/javax/microedition/m3g/Graphics3D.java
@@ -86,6 +86,7 @@ public class Graphics3D
 	float xBot, yBot, zBot, sBot, tBot;
 	float rHorizon, xMidR, zMidR, sMidR, tMidR;
 	float drawY, drawX, xL, xR, zL, zR, sL, sR, tL, tR;
+	float pwTop, pwMidL, pwBot, pwMidR, pwL, pwR;
 	float z, s, t;
 	final float[] scaleBias = new float[4];
 
@@ -105,7 +106,8 @@ public class Graphics3D
 	final float[] coY = new float[3];
 	final float[] coZ = new float[3];
 	final float[] coS = new float[3];
-	final float[] coT = new float[3];	
+	final float[] coT = new float[3];
+	final float[] coW = new float[3];
 
 
 	public Graphics3D()
@@ -205,20 +207,12 @@ public class Graphics3D
 		if (this.target == null) { throw new IllegalStateException("Cannot clear Background on a Graphics3D without a render target."); }
 
 		int color = 0;
-		int x = viewx;
-		int y = viewy;
-		int w = vieww;
-		int h = viewh;
 		boolean clearColor = true;
 		boolean clearDepth = true;
 
 		if (background != null)
 		{
 			color = background.getColor();
-			x = background.getCropX();
-			y = background.getCropY();
-			w = background.getCropWidth();
-			h = background.getCropHeight();
 			clearColor = background.isColorClearEnabled();
 			clearDepth = background.isDepthClearEnabled();
 		}
@@ -248,19 +242,40 @@ public class Graphics3D
 			{
 				Graphics grp = (Graphics) this.target;
 
-				// Fill the background with the background color
+				/* As per JSR-184, clear() always affects the whole viewport: fill it with the
+				 * background color first. The Background crop rectangle is a sampling window
+				 * into the background image, NOT the destination rectangle. */
 				grp.setColor(color);
-				grp.fillRect(x, y, w, h);
+				grp.fillRect(viewx, viewy, vieww, viewh);
 
 				// Draw the background's image if any (and there's a background)
-				if(background != null && background.getImage() != null) 
+				if(background != null && background.getImage() != null)
 				{
-					Mobile.log(Mobile.LOG_WARNING, Graphics3D.class.getPackage().getName() + "." + Graphics3D.class.getSimpleName() + ": " + "Clear with Background Image Untested");
-					for(; y < h; y++) 
+					final Image2D bgImg = background.getImage();
+
+					/* The crop rectangle (defaulting to the whole image) is mapped onto the
+					 * viewport so that it fills it completely; the image mode governs sampling
+					 * outside the image bounds (BORDER = background color, REPEAT = tile). */
+					final int cropX = background.getCropX(), cropY = background.getCropY();
+					int cropW = background.getCropWidth(), cropH = background.getCropHeight();
+					if (cropW <= 0) { cropW = bgImg.getWidth(); }
+					if (cropH <= 0) { cropH = bgImg.getHeight(); }
+					final boolean repeatX = background.getImageModeX() == Background.REPEAT;
+					final boolean repeatY = background.getImageModeY() == Background.REPEAT;
+
+					for (int py = 0; py < viewh; py++)
 					{
-						for(; x < w; x++) 
+						int sy = cropY + (int) ((long) py * cropH / viewh);
+						if (repeatY) { sy = ((sy % bgImg.getHeight()) + bgImg.getHeight()) % bgImg.getHeight(); }
+						else if (sy < 0 || sy >= bgImg.getHeight()) { continue; }
+
+						for (int px = 0; px < vieww; px++)
 						{
-							rasterData[y * canvasWidth + x] = background.getImage().getConvertedPixel(x, y);
+							int sx = cropX + (int) ((long) px * cropW / vieww);
+							if (repeatX) { sx = ((sx % bgImg.getWidth()) + bgImg.getWidth()) % bgImg.getWidth(); }
+							else if (sx < 0 || sx >= bgImg.getWidth()) { continue; }
+
+							rasterData[(py + viewy) * canvasWidth + (px + viewx)] = bgImg.getConvertedPixel(sx, sy);
 						}
 					}
 				}
@@ -414,10 +429,12 @@ public class Graphics3D
 				if (mesh.getAppearance(i) != null) { render(vertices, mesh.getIndexBuffer(i), mesh.getAppearance(i), transform, node.getScope()); }
 			}
 		}
-		else if (node instanceof Sprite3D) 
+		else if (node instanceof Sprite3D)
 		{
-			Mobile.log(Mobile.LOG_WARNING, Graphics3D.class.getPackage().getName() + "." + Graphics3D.class.getSimpleName() + ": " + "Graphics3D.render Node: Sprite3D Not Implemented!");
 			if(!node.isRenderingEnabled()) { return; }
+			/* JSR-184 scope culling, same rule as for meshes. */
+			if ((node.getScope() & this.currCam.getScope()) == 0) { return; }
+			renderSprite((Sprite3D) node, transform);
 		}
 		else if (node instanceof Group) 
 		{
@@ -442,18 +459,162 @@ public class Graphics3D
 		}
 	}
 
-	public void render(VertexBuffer vertices, IndexBuffer triangles, Appearance appearance, Transform transform) 
+	/*
+	 * Renders a Sprite3D as a screen-aligned textured rectangle, following the same
+	 * math as the JSR-184 Reference Implementation (m3g_sprite.c, m3gGetSpriteCoordinates):
+	 * the node origin and half-unit axis vectors are measured in eye space, re-aligned
+	 * to the screen axes, projected, and the resulting NDC quad is rasterized directly
+	 * with the sprite's crop as texture source.
+	 */
+	private void renderSprite(Sprite3D sprite, Transform transform)
+	{
+		final Image2D img = sprite.getImage();
+		final Appearance appearance = sprite.getAppearance();
+
+		/* As per JSR-184, a Sprite3D with no appearance (or no image) is not rendered. */
+		if (img == null || appearance == null) { return; }
+		if (!(this.target instanceof Graphics)) { return; }
+
+		/* The crop rectangle keeps its sign; negative dimensions flip the image on that axis. */
+		final int cropX = sprite.getCropX(), cropY = sprite.getCropY();
+		int cropW = sprite.getCropWidth(), cropH = sprite.getCropHeight();
+		final boolean flipX = cropW < 0, flipY = cropH < 0;
+		if (flipX) { cropW = -cropW; }
+		if (flipY) { cropH = -cropH; }
+		if (cropW == 0 || cropH == 0) { return; }
+
+		/* Intersect the crop rectangle with the image rectangle; nothing to render without overlap. */
+		final int isectX = M3GMath.max(cropX, 0), isectY = M3GMath.max(cropY, 0);
+		final int isectW = M3GMath.min(cropX + cropW, img.getWidth()) - isectX;
+		final int isectH = M3GMath.min(cropY + cropH, img.getHeight()) - isectY;
+		if (isectW <= 0 || isectH <= 0) { return; }
+
+		if (transform == null) { transform = new Transform(); }
+
+		/* Model-view: the sprite's rotation/scale only affect its size, never its screen alignment. */
+		final Transform modelView = new Transform(transform);
+		modelView.preMultiply(this.currCamTransInv);
+
+		/* Origin and half-unit axis points in eye space (affine transform, w stays 1). */
+		final float[] eye = { 0,0,0,1,  0.5f,0,0,1,  0,0.5f,0,1 };
+		modelView.transform(eye);
+		final float ox = eye[0]/eye[3], oy = eye[1]/eye[3], oz = eye[2]/eye[3];
+		final float dx0 = eye[4]/eye[7] - ox, dy0 = eye[5]/eye[7] - oy, dz0 = eye[6]/eye[7] - oz;
+		final float dx1 = eye[8]/eye[11] - ox, dy1 = eye[9]/eye[11] - oy, dz1 = eye[10]/eye[11] - oz;
+		final float halfUnitX = M3GMath.sqrt(dx0*dx0 + dy0*dy0 + dz0*dz0);
+		final float halfUnitY = M3GMath.sqrt(dx1*dx1 + dy1*dy1 + dz1*dz1);
+
+		/* Project the origin plus screen-aligned extent points. */
+		this.currCam.getProjection(projectionMatrix);
+		final float[] clip = { ox,oy,oz,1,  ox+halfUnitX,oy,oz,1,  ox,oy+halfUnitY,oz,1 };
+		projectionMatrix.transform(clip);
+		if (clip[3] <= 0f || clip[7] <= 0f || clip[11] <= 0f) { return; } /* Behind the camera */
+
+		float ndcX = clip[0]/clip[3], ndcY = clip[1]/clip[3];
+		final float ndcZ = clip[2]/clip[3];
+		if (ndcZ < -1f || ndcZ > 1f) { return; } /* Outside the depth range */
+		float halfW = M3GMath.abs(clip[4]/clip[7] - ndcX);
+		float halfH = M3GMath.abs(clip[9]/clip[11] - ndcY);
+
+		if (sprite.isScaled())
+		{
+			/* Adjust the position and size according to the (possibly partly outside) crop rectangle. */
+			final float unitX = halfW / (float) cropW, unitY = halfH / (float) cropH;
+			ndcX -= (2*cropX + cropW - 2*isectX - isectW) * unitX;
+			ndcY += (2*cropY + cropH - 2*isectY - isectH) * unitY;
+			halfW = unitX * isectW;
+			halfH = unitY * isectH;
+		}
+		else
+		{
+			/* Non-scaled sprites take their size in pixels from the crop rectangle. */
+			ndcX -= (float)(2*cropX + cropW - 2*isectX - isectW) / (float) vieww;
+			ndcY += (float)(2*cropY + cropH - 2*isectY - isectH) / (float) viewh;
+			halfW = (float) isectW / (float) vieww;
+			halfH = (float) isectH / (float) viewh;
+		}
+
+		/* NDC -> viewport-relative pixels (same mapping as the triangle rasterizer). */
+		final float sx0 = (ndcX - halfW + 1f) * vieww / 2f;
+		final float sx1 = (ndcX + halfW + 1f) * vieww / 2f;
+		final float sy0 = (1f - (ndcY + halfH)) * viewh / 2f;
+		final float sy1 = (1f - (ndcY - halfH)) * viewh / 2f;
+		final float spanX = sx1 - sx0, spanY = sy1 - sy0;
+		if (spanX <= 0f || spanY <= 0f) { return; }
+
+		final int pixL = M3GMath.max(M3GMath.roundPositive(sx0), 0);
+		final int pixR = M3GMath.min(M3GMath.roundPositive(sx1), vieww);
+		final int pixT = M3GMath.max(M3GMath.roundPositive(sy0), 0);
+		final int pixB = M3GMath.min(M3GMath.roundPositive(sy1), viewh);
+		if (pixL >= pixR || pixT >= pixB) { return; }
+
+		final CompositingMode compositingMode = appearance.getCompositingMode() != null ? appearance.getCompositingMode() : new CompositingMode();
+		final Fog fog = appearance.getFog();
+		final int alphaThreshold = (int) (compositingMode.getAlphaThreshold() * 255);
+		final float alphaFactor = sprite.getAlphaFactor();
+		final boolean depthTest = compositingMode.isDepthTestEnabled() && isDepthBufferEnabled();
+		final boolean depthWrite = depthTest && compositingMode.isDepthWriteEnabled();
+
+		for (int y = pixT; y < pixB; y++)
+		{
+			final float v = (y + 0.5f - sy0) / spanY;
+			int texY = isectY + (int) ((flipY ? 1f - v : v) * isectH);
+			if (texY < isectY) { texY = isectY; } else if (texY >= isectY + isectH) { texY = isectY + isectH - 1; }
+
+			for (int x = pixL; x < pixR; x++)
+			{
+				/* Depth test against the same buffer and convention used by triangles. */
+				if (depthTest && this.depthBuffer[this.vieww * y + x] < ndcZ) { continue; }
+
+				final float u = (x + 0.5f - sx0) / spanX;
+				int texX = isectX + (int) ((flipX ? 1f - u : u) * isectW);
+				if (texX < isectX) { texX = isectX; } else if (texX >= isectX + isectW) { texX = isectX + isectW - 1; }
+
+				int paintPixel = img.getConvertedPixel(texX, texY);
+				final int alpha = (int) (((paintPixel >> 24) & 0xFF) * alphaFactor);
+				if (alpha < alphaThreshold || alpha == 0) { continue; } /* Alpha test discards the fragment before any writes */
+
+				if (fog != null)
+				{
+					if (fog.getMode() == Fog.LINEAR)
+					{
+						fogFactor = M3GMath.max(0, M3GMath.min(1, (fog.getFarDistance() - ndcZ) / (fog.getFarDistance() - fog.getNearDistance()) * 250));
+					}
+					else
+					{
+						fogFactor = M3GMath.abs(M3GMath.exp(-fog.getDensity() * ndcZ));
+						fogFactor = M3GMath.max(0, M3GMath.min(1, fogFactor));
+					}
+					paintPixel = blendFog(paintPixel, fog.getColor());
+				}
+
+				final int finalPixel = (compositingMode.getBlending() == CompositingMode.REPLACE && alpha == 255) ? paintPixel :
+					blendPixels(rasterData[(y+viewy) * canvasWidth + (x+viewx)], paintPixel, alpha, compositingMode.getBlending());
+
+				rasterData[(y+viewy) * canvasWidth + (x+viewx)] = finalPixel;
+
+				if (depthWrite) { this.depthBuffer[this.vieww * y + x] = ndcZ; }
+			}
+		}
+	}
+
+	public void render(VertexBuffer vertices, IndexBuffer triangles, Appearance appearance, Transform transform)
 	{ this.render(vertices, triangles, appearance, transform, -1); }
 
-	public void render(VertexBuffer vertices, IndexBuffer triangles, Appearance appearance, Transform transform, int scope) 
+	public void render(VertexBuffer vertices, IndexBuffer triangles, Appearance appearance, Transform transform, int scope)
 	{
-		/* TODO: Check the scope used by the submesh to find out which lights need to be applied, if it needs to be rendered, etc. */
-
 		/* As per JSR-184, if vertices, triangles or appearence are null, throw a NullPointerException. */
 		if (vertices == null || triangles == null || appearance == null) { throw new NullPointerException("Tried to render a submesh with incomplete info."); }
-		
+
 		/* Also per JSR-184, throw IllegalStateException if the application tries to render without having set up a render target or camera beforehand. */
 		if (this.target == null || this.currCam == null) { throw new IllegalStateException("Tried to render a submesh without having a render target or camera first."); }
+
+		/*
+		 * JSR-184 scope culling: geometry is only rendered if its scope intersects the
+		 * camera's scope. Games hide nodes by calling setScope(0) on them (e.g. pooled
+		 * objects parked inside a Group), so ignoring this draws them all at the origin.
+		 */
+		if ((scope & this.currCam.getScope()) == 0) { return; }
 		
 		// if `vertices` or `triangles` violates the constraints
 		//    defined in VertexBuffer or IndexBuffer
@@ -503,6 +664,12 @@ public class Graphics3D
 
 		final VertexArray texCoords = vertices.getTexCoords(0, scaleBias); // get Texture coordinates
 
+		/* Texture wrapping mode and dimensions, applied per-pixel while sampling */
+		final boolean texRepeatS = (tex != null) && tex.getWrappingS() == Texture2D.WRAP_REPEAT;
+		final boolean texRepeatT = (tex != null) && tex.getWrappingT() == Texture2D.WRAP_REPEAT;
+		final int texW = (teximg != null) ? teximg.getWidth() : 0;
+		final int texH = (teximg != null) ? teximg.getHeight() : 0;
+
 		if (tex != null) { tex.getCompositeTransform(texcomptr); }
 
 		// Scale and translate texture coordinates (same scaleBias)
@@ -533,8 +700,63 @@ public class Graphics3D
 		final float[] texVert = new float[4 * vertPos.getVertexCount()];
 		if (texCoords != null) { textr.transform(texCoords, texVert, true); }
 
+		/*
+		 * Near-plane distance for clipping: the camera's actual near plane (where
+		 * w_clip == -z_eye == near), NOT the depth-range near (which defaults to 0).
+		 * Clipping against w >= 0 leaves vertices at w == 0 that blow up to infinity
+		 * in the perspective division, dropping every triangle that crosses the plane.
+		 */
+		final float[] projParams = new float[4];
+		final int projType = this.currCam.getProjection(projParams);
+		final float clipNear = (projType == Camera.PERSPECTIVE) ? M3GMath.max(projParams[2], 1e-4f) : 1e-4f;
+
 		// Create Triangle objects (fromVertsAndTris already does culling and clipping)
-		final Triangle[] trisScreen = Triangle.fromVertAndTris(vertClip, texVert, triangles.getIndexArray(), renderableTriangles, near, cullingMode);
+		final Triangle[] trisScreen = Triangle.fromVertAndTris(vertClip, texVert, triangles.getIndexArray(), renderableTriangles, clipNear, cullingMode);
+
+		/*
+		 * Per-triangle flat lighting (JSR-184 lighting requires a Material on the
+		 * Appearance). Lights and vertices are brought to camera space once per
+		 * render; each triangle then gets a diffuse+ambient factor from its
+		 * geometric normal, applied to the rasterized color below.
+		 */
+		final Material material = appearance.getMaterial();
+		float[] litVerts = null;
+		float[][] litLights = null; /* per light: [mode, r, g, b, x, y, z] with color premultiplied by intensity */
+		if (material != null && !this.currLights.isEmpty())
+		{
+			litVerts = new float[4 * vertPos.getVertexCount()];
+			final Transform mv = new Transform();
+			mv.postTranslate(scaleBias[1], scaleBias[2], scaleBias[3]);
+			mv.postScale(scaleBias[0], scaleBias[0], scaleBias[0]);
+			mv.preMultiply(transform);
+			mv.preMultiply(this.currCamTransInv);
+			mv.transform(vertPos, litVerts, true);
+
+			litLights = new float[this.currLights.size()][7];
+			final float[] lv = new float[16];
+			for (int li = 0; li < this.currLights.size(); li++)
+			{
+				final Light light = this.currLights.get(li);
+				if (light == null) { litLights[li][0] = -1; continue; }
+				final Transform lt = new Transform(this.currLightTrans.get(li));
+				lt.preMultiply(this.currCamTransInv);
+				lt.get(lv);
+				litLights[li][0] = light.getMode();
+				litLights[li][1] = ((light.getColor() >> 16) & 0xFF) / 255f * light.getIntensity();
+				litLights[li][2] = ((light.getColor() >> 8) & 0xFF) / 255f * light.getIntensity();
+				litLights[li][3] = (light.getColor() & 0xFF) / 255f * light.getIntensity();
+				if (light.getMode() == Light.DIRECTIONAL)
+				{
+					/* Light direction: -Z axis of the light's transform, in camera space. */
+					litLights[li][4] = -lv[2]; litLights[li][5] = -lv[6]; litLights[li][6] = -lv[10];
+				}
+				else /* OMNI and SPOT (treated as OMNI): light position in camera space. */
+				{
+					litLights[li][4] = lv[3]; litLights[li][5] = lv[7]; litLights[li][6] = lv[11];
+				}
+			}
+		}
+		float litR = 1f, litG = 1f, litB = 1f;
 
 		// At this point the triangles in `trisScreen` are actually
 		// projected to Normalized Device Coordinates, but they will be tranformed
@@ -573,6 +795,49 @@ public class Graphics3D
 				coZ[0] = trisScreen[tri_id].zA(); coZ[1] = trisScreen[tri_id].zB(); coZ[2] = trisScreen[tri_id].zC();
 				coS[0] = trisScreen[tri_id].sA(); coS[1] = trisScreen[tri_id].sB(); coS[2] = trisScreen[tri_id].sC();
 				coT[0] = trisScreen[tri_id].tA(); coT[1] = trisScreen[tri_id].tB(); coT[2] = trisScreen[tri_id].tC();
+				coW[0] = trisScreen[tri_id].invW[0]; coW[1] = trisScreen[tri_id].invW[1]; coW[2] = trisScreen[tri_id].invW[2];
+
+				if (litVerts != null)
+				{
+					/* Flat lighting factor for this triangle from its geometric normal in camera space. */
+					final int liA = trisScreen[tri_id].getIndex(0) * 4;
+					final int liB = trisScreen[tri_id].getIndex(1) * 4;
+					final int liC = trisScreen[tri_id].getIndex(2) * 4;
+					final float e1x = litVerts[liB] - litVerts[liA], e1y = litVerts[liB+1] - litVerts[liA+1], e1z = litVerts[liB+2] - litVerts[liA+2];
+					final float e2x = litVerts[liC] - litVerts[liA], e2y = litVerts[liC+1] - litVerts[liA+1], e2z = litVerts[liC+2] - litVerts[liA+2];
+					float nx = e1y*e2z - e1z*e2y, ny = e1z*e2x - e1x*e2z, nz = e1x*e2y - e1y*e2x;
+					final float nlen = M3GMath.sqrt(nx*nx + ny*ny + nz*nz);
+					litR = 0f; litG = 0f; litB = 0f;
+					if (nlen > 0f)
+					{
+						nx /= nlen; ny /= nlen; nz /= nlen;
+						for (int li = 0; li < litLights.length; li++)
+						{
+							final float mode = litLights[li][0];
+							if (mode == Light.AMBIENT)
+							{
+								litR += litLights[li][1]; litG += litLights[li][2]; litB += litLights[li][3];
+							}
+							else if (mode == Light.DIRECTIONAL || mode == Light.OMNI || mode == Light.SPOT)
+							{
+								float lx, ly, lz;
+								if (mode == Light.DIRECTIONAL) { lx = -litLights[li][4]; ly = -litLights[li][5]; lz = -litLights[li][6]; }
+								else
+								{
+									/* Direction from the triangle towards the light position. */
+									lx = litLights[li][4] - litVerts[liA]; ly = litLights[li][5] - litVerts[liA+1]; lz = litLights[li][6] - litVerts[liA+2];
+								}
+								final float llen = M3GMath.sqrt(lx*lx + ly*ly + lz*lz);
+								if (llen <= 0f) { continue; }
+								/* Two-sided diffuse term, so winding/normal direction doesn't black out faces. */
+								final float ndl = M3GMath.abs((nx*lx + ny*ly + nz*lz) / llen);
+								litR += litLights[li][1] * ndl; litG += litLights[li][2] * ndl; litB += litLights[li][3] * ndl;
+							}
+						}
+					}
+					else { litR = 1f; litG = 1f; litB = 1f; }
+					if (litR > 1f) { litR = 1f; } if (litG > 1f) { litG = 1f; } if (litB > 1f) { litB = 1f; }
+				}
 
 				// x and y coordinates are special cases where the resulting top, mid and bot values should be in decreasing order (top > mid > bot)
 				if (coY[ord[1]] < coY[ord[0]]) 
@@ -600,6 +865,7 @@ public class Graphics3D
 				zTop = coZ[ord[0]]; zMidL = coZ[ord[1]]; zBot = coZ[ord[2]];
 				sTop = coS[ord[0]]; sMidL = coS[ord[1]]; sBot = coS[ord[2]];
 				tTop = coT[ord[0]]; tMidL = coT[ord[1]]; tBot = coT[ord[2]];
+				pwTop = coW[ord[0]]; pwMidL = coW[ord[1]]; pwBot = coW[ord[2]];
 
 				// Calculate the right horizon
 				rHorizon = (yMid - yTop) / (yBot - yTop);
@@ -607,9 +873,10 @@ public class Graphics3D
 				zMidR = zTop + rHorizon * (zBot - zTop);
 				sMidR = sTop + rHorizon * (sBot - sTop);
 				tMidR = tTop + rHorizon * (tBot - tTop);
+				pwMidR = pwTop + rHorizon * (pwBot - pwTop);
 
 				// Swap midpoints if necessary
-				if (xMidL > xMidR) 
+				if (xMidL > xMidR)
 				{
 					float temp;
 
@@ -618,6 +885,7 @@ public class Graphics3D
 					temp = zMidL; zMidL = zMidR; zMidR = temp;
 					temp = sMidL; sMidL = sMidR; sMidR = temp;
 					temp = tMidL; tMidL = tMidR; tMidR = temp;
+					temp = pwMidL; pwMidL = pwMidR; pwMidR = temp;
 				}
 
 				// Draw both halves of the triangle
@@ -662,12 +930,12 @@ public class Graphics3D
 						tR = half == 0
 							? tTop + drawY * (tMidR - tTop)
 							: tBot + drawY * (tMidR - tBot);
-
-						// TODO: Proper texture perspective correction
-						if (perspectiveCorrectionEnabled) 
-						{			
-							
-						}
+						pwL = half == 0
+							? pwTop + drawY * (pwMidL - pwTop)
+							: pwBot + drawY * (pwMidL - pwBot);
+						pwR = half == 0
+							? pwTop + drawY * (pwMidR - pwTop)
+							: pwBot + drawY * (pwMidR - pwBot);
 
 						ixL = M3GMath.max(M3GMath.roundPositive(xL), 0);
 						ixR = M3GMath.min(M3GMath.roundPositive(xR), vieww);
@@ -685,29 +953,50 @@ public class Graphics3D
 								z = (zL + drawX * (zR - zL));
 								
 								// Only depth test if the compositingMode has the feature enabled. If compositingMode is not set, check if this target has depthBuffer enabled
-								if(compositingMode.isDepthTestEnabled() && isDepthBufferEnabled())
+								final boolean depthEnabled = compositingMode.isDepthTestEnabled() && isDepthBufferEnabled();
+								if(depthEnabled)
 								{
 									// Depth testing and depth buffer updates don't need to match against the pixel's translated viewport coordinates, if they are translated
 									if (this.depthBuffer[this.vieww * y + x] < z) { continue; } // Skip if this pixel is not visible
-
-									// Update the depth buffer if depth write is enabled
-									if (compositingMode.isDepthWriteEnabled()) { this.depthBuffer[this.vieww * y + x] = z; }
 								}
 								s = sL + drawX * (sR - sL);
 								t = tL + drawX * (tR - tL);
+								/* Perspective-correct texturing: s/w, t/w and 1/w interpolate linearly in screen space */
+								final float pw = pwL + drawX * (pwR - pwL);
+								if (pw > 1e-9f || pw < -1e-9f) { s /= pw; t /= pw; }
 
 								// If there's no texture coords or a texture image, we default to rendering with vertex colors. (also used for debug render modes)
 								int paintPixel = 0xFF000000 | vertices.getDefaultColor(); // It's forced to opaque, maybe that shouldn't be done for untextured polygons, but helps some games like Brick Breaker Revolution
-								if(tex != null && texCoords != null && !Mobile.M3GRenderUntexturedPolygons && !Mobile.M3GRenderWireframe) { paintPixel = teximg.getConvertedPixel(M3GMath.roundPositive(s), M3GMath.roundPositive(t)); }
-								
-								if (((paintPixel >> 24) & 0xFF) < (int) (compositingMode.getAlphaThreshold() * 255)) { continue; } // Skip transparent pixels below the alpha threshold
+								if(tex != null && texCoords != null && !Mobile.M3GRenderUntexturedPolygons && !Mobile.M3GRenderWireframe)
+								{
+									/* JSR-184 texture wrapping: REPEAT tiles the image, CLAMP samples the edge.
+									 * Out-of-range coordinates must never index outside the image. */
+									int texX = M3GMath.roundPositive(s), texY = M3GMath.roundPositive(t);
+									if (texRepeatS) { texX = ((texX % texW) + texW) % texW; }
+									else if (texX < 0) { texX = 0; } else if (texX >= texW) { texX = texW - 1; }
+									if (texRepeatT) { texY = ((texY % texH) + texH) % texH; }
+									else if (texY < 0) { texY = 0; } else if (texY >= texH) { texY = texH - 1; }
+									paintPixel = teximg.getConvertedPixel(texX, texY);
+								}
+
+								/*
+								 * Alpha test BEFORE any depth write: fully transparent fragments must not
+								 * occlude geometry drawn later (games rely on this — e.g. tree canopies
+								 * with alpha cutouts drawn before the ground). The depth buffer is only
+								 * updated by fragments that survive this test.
+								 */
+								final int fragAlpha = (paintPixel >> 24) & 0xFF;
+								if (fragAlpha == 0 || fragAlpha < (int) (compositingMode.getAlphaThreshold() * 255)) { continue; } // Skip transparent pixels below the alpha threshold
+
+								// Update the depth buffer if depth write is enabled
+								if (depthEnabled && compositingMode.isDepthWriteEnabled()) { this.depthBuffer[this.vieww * y + x] = z; }
 
 								int alpha; // Image2D converts to ARGB format
 
 								if (vertices.getColors() != null) // We have to do texture blending, as we have vertex colors and any available texture goes on top of them
 								{
 									// Get vertex index color TODO: This doesn't yet result in proper blending
-									for (int i = 0; i < 3; i++) 
+									for (int i = 0; i < 3; i++)
 									{
 										vertices.getColors().get(trisScreen[tri_id].getIndex(ord[i]), 1, color_vertex);
 										colors[i] = (vertices.getColors().getComponentCount() == 3)
@@ -742,7 +1031,40 @@ public class Graphics3D
 
 									// Blend with texture pixel if there's one, otherwise, just use the interpolated vertex color directly
 									if(tex == null && texCoords == null) { paintPixel = (alpha << 24) | (r << 16) | (g << 8) | b; }
-									else { paintPixel = blendPixels(paintPixel, (alpha << 24) | (r << 16) | (g << 8) | b, alpha, tex.getBlending()); }
+									else
+									{
+										/*
+										 * JSR-184 texture blending combines the TEXTURE sample with the
+										 * interpolated fragment (vertex) color: REPLACE keeps the texture
+										 * as-is, MODULATE multiplies both. Other modes keep the previous
+										 * alpha-blend approximation.
+										 */
+										switch (tex.getBlending())
+										{
+											case Texture2D.FUNC_REPLACE:
+												/* paintPixel already holds the texture sample. */
+												alpha = (paintPixel >>> 24);
+												break;
+											case Texture2D.FUNC_MODULATE:
+											{
+												final int tA = (paintPixel >>> 24), tR = (paintPixel >> 16) & 0xFF, tG = (paintPixel >> 8) & 0xFF, tB = paintPixel & 0xFF;
+												alpha = (tA * alpha) / 255;
+												paintPixel = (alpha << 24) | (((tR * r) / 255) << 16) | (((tG * g) / 255) << 8) | ((tB * b) / 255);
+												break;
+											}
+											default:
+												paintPixel = blendPixels(paintPixel, (alpha << 24) | (r << 16) | (g << 8) | b, alpha, tex.getBlending());
+										}
+									}
+								}
+
+								if (litVerts != null)
+								{
+									/* Modulate the rasterized color with this triangle's flat lighting factor. */
+									paintPixel = (paintPixel & 0xFF000000)
+										| (((int) (((paintPixel >> 16) & 0xFF) * litR)) << 16)
+										| (((int) (((paintPixel >> 8) & 0xFF) * litG)) << 8)
+										| ((int) ((paintPixel & 0xFF) * litB));
 								}
 
 								alpha = (paintPixel >> 24) & 0xFF; // Image2D converts to ARGB format

--- a/src/javax/microedition/m3g/Sprite3D.java
+++ b/src/javax/microedition/m3g/Sprite3D.java
@@ -39,9 +39,15 @@ public class Sprite3D extends Node
 
 	public Sprite3D(boolean isScaled, Image2D img, Appearance a)
 	{
+		/* As per JSR-184, the image cannot be null, and the crop rectangle initially covers the whole image. */
+		if (img == null) { throw new NullPointerException("Cannot create a Sprite3D with a null image."); }
 		scaled = isScaled;
 		image = img;
 		appearance = a;
+		cropx = 0;
+		cropy = 0;
+		cropw = img.getWidth();
+		croph = img.getHeight();
 	}
 
 	public Appearance getAppearance() { return appearance; }

--- a/src/javax/microedition/m3g/Triangle.java
+++ b/src/javax/microedition/m3g/Triangle.java
@@ -42,113 +42,156 @@ class Triangle
 		// sC, tC, rC, qC;
 		// 0   1   2   3
 
-	private static int[] bufIndex;
+	/* 1/w of each vertex after projection, for perspective-correct texture mapping. */
+	final float[] invW = new float[] { 1f, 1f, 1f };
 
-	private int triangleIndex = 0;
+	/* Effective vertex indices of the source triangle (after strip-winding correction). */
+	private int idxA, idxB, idxC;
 
-	Triangle(float[] vertices, int triIndex) 
-	{ 
+	Triangle(float[] vertices, int ia, int ib, int ic)
+	{
 		v = vertices;
-		triangleIndex = triIndex;
+		idxA = ia; idxB = ib; idxC = ic;
 	}
 
 	public static final Triangle[] fromVertAndTris(float[] vert, float[] texc, int[] tris, int[] renderableTriangles, float near, int cullingMode)
 	{
 		renderableTriangles[0] = 0;
 		boolean sharesVertices = false;
-		final Triangle[] result = new Triangle[tris.length / 3];
+		/* Near-plane clipping can split a crossing triangle into two. */
+		final Triangle[] result = new Triangle[(tris.length / 3) * 2];
 
-		// Index buffer data. We don't need to make a sub-array copy for each triangle.
-		// We can then just track it statically and each triangle's index will take care of the rest
-		bufIndex = tris;
+		final float[] inV = new float[12];
+		final float[] inT = new float[12];
+		final float[] outV = new float[16]; /* Up to 4 vertices after clipping against one plane */
+		final float[] outT = new float[16];
 
-		for (int tri_id = 0; tri_id < tris.length / 3; tri_id++) 
+		int prevA = 0, prevB = 0, prevC = 0; /* effective indices of the previous triangle */
+		for (int tri_id = 0; tri_id < tris.length / 3; tri_id++)
 		{
-			if (tri_id > 0) 
+			/*
+			 * Triangle-strip winding correction: consecutive triangles sharing an edge
+			 * alternate their winding, so swap two indices to normalize it. The swap is
+			 * done on LOCAL copies, comparing against the previous triangle's EFFECTIVE
+			 * (post-swap) indices — writing the swap back into the IndexBuffer's array
+			 * would corrupt the mesh cumulatively across renders (the detection would
+			 * then run on already-swapped data, flipping different triangles each time).
+			 */
+			int ia = tris[3 * tri_id + 0], ib = tris[3 * tri_id + 1], ic = tris[3 * tri_id + 2];
+			if (tri_id > 0)
 			{
-				sharesVertices = (tris[3* tri_id + 0] == tris[3* (tri_id-1) + 1] &&
-								tris[3* tri_id + 1] == tris[3* (tri_id-1) + 2]) ||
-								(tris[3* tri_id + 1] == tris[3* (tri_id-1) + 0] &&
-								tris[3* tri_id + 2] == tris[3* (tri_id-1) + 1]);
+				sharesVertices = (ia == prevB && ib == prevC) || (ib == prevA && ic == prevB);
 
-				// Swap vertices for triangles if sharing is detected
-				if (sharesVertices) 
+				if (sharesVertices)
 				{
-					// Swap indexA and indexB
-					int temp = tris[3 * tri_id + 0];
-					tris[3 * tri_id + 0] = tris[3 * tri_id + 1];
-					tris[3 * tri_id + 1] = temp;
+					final int temp = ia;
+					ia = ib;
+					ib = temp;
+				}
+			}
+			prevA = ia; prevB = ib; prevC = ic;
+
+			for (int i = 0; i < 3; i++)
+			{
+				final int idx = 4 * (i == 0 ? ia : (i == 1 ? ib : ic));
+				inV[4*i]   = vert[idx];     inV[4*i+1] = vert[idx + 1];
+				inV[4*i+2] = vert[idx + 2]; inV[4*i+3] = vert[idx + 3];
+				if (texc != null)
+				{
+					inT[4*i]   = texc[idx];     inT[4*i+1] = texc[idx + 1];
+					inT[4*i+2] = texc[idx + 2]; inT[4*i+3] = texc[idx + 3];
 				}
 			}
 
-			result[renderableTriangles[0]] = new Triangle(new float[] // Vertex positions
+			/*
+			 * Clip against the near plane (w >= near) in clip space, interpolating both
+			 * positions and texture coordinates. Vertices behind the camera would otherwise
+			 * explode to huge screen coordinates after the perspective division.
+			 */
+			final int outCount = clipNearPlane(inV, inT, texc != null, near, outV, outT);
+			if (outCount < 3) { continue; }
+
+			/* Triangulate the resulting polygon (3 or 4 vertices) as a fan. */
+			for (int fan = 0; fan + 2 < outCount; fan++)
 			{
-				vert[4 * tris[3 * tri_id + 0] + 0], // xA
-				vert[4 * tris[3 * tri_id + 0] + 1], // yA
-				vert[4 * tris[3 * tri_id + 0] + 2], // zA
-				vert[4 * tris[3 * tri_id + 0] + 3], // wA
-				vert[4 * tris[3 * tri_id + 1] + 0], // xB
-				vert[4 * tris[3 * tri_id + 1] + 1], // yB
-				vert[4 * tris[3 * tri_id + 1] + 2], // zB
-				vert[4 * tris[3 * tri_id + 1] + 3], // wB
-				vert[4 * tris[3 * tri_id + 2] + 0], // xC
-				vert[4 * tris[3 * tri_id + 2] + 1], // yC
-				vert[4 * tris[3 * tri_id + 2] + 2], // zC
-				vert[4 * tris[3 * tri_id + 2] + 3]  // wC
-			}, 
-			tri_id); // Triangle Index
+				final Triangle tri = new Triangle(new float[]
+				{
+					outV[0], outV[1], outV[2], outV[3],
+					outV[4*(fan+1)], outV[4*(fan+1)+1], outV[4*(fan+1)+2], outV[4*(fan+1)+3],
+					outV[4*(fan+2)], outV[4*(fan+2)+1], outV[4*(fan+2)+2], outV[4*(fan+2)+3]
+				}, ia, ib, ic);
 
-			// Check if this triangle should be rendered or clipped/culled.
-			for (int i = 0; i < 3; i++) // Go through vertices A, B and C
-			{ 
-				if (result[renderableTriangles[0]].v[i * 4 + 3] >= near) // W cannot be smaller than the near plane, otherwise we'll erroneously cull triangles close to the camera
-				{ 
-					result[renderableTriangles[0]].v[i * 4 + 0] /= result[renderableTriangles[0]].v[i * 4 + 3]; // x / w
-					result[renderableTriangles[0]].v[i * 4 + 1] /= result[renderableTriangles[0]].v[i * 4 + 3]; // y / w
-					result[renderableTriangles[0]].v[i * 4 + 2] /= result[renderableTriangles[0]].v[i * 4 + 3]; // z / w
+				// Perspective division for culling and visibility checks (all w >= near now)
+				for (int i = 0; i < 3; i++)
+				{
+					tri.v[i * 4 + 0] /= tri.v[i * 4 + 3];
+					tri.v[i * 4 + 1] /= tri.v[i * 4 + 3];
+					tri.v[i * 4 + 2] /= tri.v[i * 4 + 3];
 				}
-			}
 
-			boolean cullTriangle = (cullingMode == PolygonMode.CULL_BACK && result[renderableTriangles[0]].isCounterClockwise()) ||
-								(cullingMode == PolygonMode.CULL_FRONT && !result[renderableTriangles[0]].isCounterClockwise());
+				final boolean cullTriangle = (cullingMode == PolygonMode.CULL_BACK && tri.isCounterClockwise()) ||
+									(cullingMode == PolygonMode.CULL_FRONT && !tri.isCounterClockwise());
+				if (cullTriangle) { continue; }
 
-			if (!cullTriangle)
-			{
-				// Move visible triangles (not clipped nor culled) to the front of the array
-				if(!result[renderableTriangles[0]].clip()) 
-				{ 
-					// We now have to restore the renderable geometry back to its original coordinates, otherwise rendering will be broken
-					for (int i = 0; i < 3; i++) 
-					{
-						result[renderableTriangles[0]].v[i * 4 + 0] *= result[renderableTriangles[0]].v[i * 4 + 3]; // x * w
-						result[renderableTriangles[0]].v[i * 4 + 1] *= result[renderableTriangles[0]].v[i * 4 + 3]; // y * w
-						result[renderableTriangles[0]].v[i * 4 + 2] *= result[renderableTriangles[0]].v[i * 4 + 3]; // z * w
-					}
+				if (tri.clip()) { continue; }
 
-					// Triangle will be rendered, so we can now bother with allocating texture coordinates
-					result[renderableTriangles[0]].setTexCoords(texc == null ? null : new float[] // Tex Coordinates
-					{
-						texc[4 * tris[3 * tri_id + 0] + 0], // sA
-						texc[4 * tris[3 * tri_id + 0] + 1], // tA
-						texc[4 * tris[3 * tri_id + 0] + 2], // rA
-						texc[4 * tris[3 * tri_id + 0] + 3], // qA
-						texc[4 * tris[3 * tri_id + 1] + 0], // sB
-						texc[4 * tris[3 * tri_id + 1] + 1], // tB
-						texc[4 * tris[3 * tri_id + 1] + 2], // rB
-						texc[4 * tris[3 * tri_id + 1] + 3], // qB
-						texc[4 * tris[3 * tri_id + 2] + 0], // sC
-						texc[4 * tris[3 * tri_id + 2] + 1], // tC
-						texc[4 * tris[3 * tri_id + 2] + 2], // rC
-						texc[4 * tris[3 * tri_id + 2] + 3]  // qC
-					});
-
-					result[renderableTriangles[0]].project(); 
-					renderableTriangles[0]++;
+				// We now have to restore the renderable geometry back to its original coordinates, otherwise rendering will be broken
+				for (int i = 0; i < 3; i++)
+				{
+					tri.v[i * 4 + 0] *= tri.v[i * 4 + 3];
+					tri.v[i * 4 + 1] *= tri.v[i * 4 + 3];
+					tri.v[i * 4 + 2] *= tri.v[i * 4 + 3];
 				}
+
+				tri.setTexCoords(texc == null ? null : new float[]
+				{
+					outT[0], outT[1], outT[2], outT[3],
+					outT[4*(fan+1)], outT[4*(fan+1)+1], outT[4*(fan+1)+2], outT[4*(fan+1)+3],
+					outT[4*(fan+2)], outT[4*(fan+2)+1], outT[4*(fan+2)+2], outT[4*(fan+2)+3]
+				});
+
+				tri.project();
+				result[renderableTriangles[0]] = tri;
+				renderableTriangles[0]++;
 			}
 		}
 
 		return result;
+	}
+
+	/*
+	 * Sutherland-Hodgman clip of one triangle against the near plane (w >= near).
+	 * Writes the resulting polygon (0, 3 or 4 vertices) into outV/outT and returns
+	 * its vertex count. Positions and texture coordinates interpolate linearly in
+	 * clip space, which is exact for both.
+	 */
+	private static int clipNearPlane(float[] inV, float[] inT, boolean hasTex, float near, float[] outV, float[] outT)
+	{
+		int outCount = 0;
+		for (int i = 0; i < 3; i++)
+		{
+			final int j = (i + 1) % 3;
+			final float wi = inV[4*i+3], wj = inV[4*j+3];
+			final boolean insideI = wi >= near, insideJ = wj >= near;
+
+			if (insideI)
+			{
+				System.arraycopy(inV, 4*i, outV, 4*outCount, 4);
+				if (hasTex) { System.arraycopy(inT, 4*i, outT, 4*outCount, 4); }
+				outCount++;
+			}
+			if (insideI != insideJ)
+			{
+				final float amt = (near - wi) / (wj - wi);
+				for (int c = 0; c < 4; c++)
+				{
+					outV[4*outCount + c] = inV[4*i + c] + amt * (inV[4*j + c] - inV[4*i + c]);
+					if (hasTex) { outT[4*outCount + c] = inT[4*i + c] + amt * (inT[4*j + c] - inT[4*i + c]); }
+				}
+				outCount++;
+			}
+		}
+		return outCount;
 	}
 
 	public final float xA() { return v[4 * 0 + 0]; }
@@ -177,7 +220,7 @@ class Triangle
 	public final float rC() { return t[4 * 2 + 2]; }
 	public final float qC() { return t[4 * 2 + 3]; }
 
-	public final int getIndex(int index) { return bufIndex[3 * triangleIndex + index]; }
+	public final int getIndex(int index) { return index == 0 ? idxA : (index == 1 ? idxB : idxC); }
 
 	public final boolean clip() 
 	{		
@@ -215,20 +258,26 @@ class Triangle
 	public final void project()
 	{
 		// Apply perspective division to the triangle, it's going to NDC
-		for (int i = 0; i < 3; i++) 
+		for (int i = 0; i < 3; i++)
 		{
+			final float w = v[4 * i + 3];
+
+			/* Keep 1/w around: the rasterizer interpolates s/w, t/w and 1/w linearly in
+			 * screen space and divides per-pixel for perspective-correct texturing. */
+			invW[i] = (w > M3GMath.EPSILON) ? (1f / w) : 1f;
+
 			// Project vertex
-			v[4 * i + 0] /= v[4 * i + 3]; // x / w
-			v[4 * i + 1] /= v[4 * i + 3]; // y / w
-			v[4 * i + 2] /= v[4 * i + 3]; // z / w
+			v[4 * i + 0] /= w; // x / w
+			v[4 * i + 1] /= w; // y / w
+			v[4 * i + 2] /= w; // z / w
 			v[4 * i + 3] = 1f;  // Set w to 1
 
-			// Project texture coordinates
-			t[4 * i + 0] /= v[4 * i + 3]; // u / w
-			t[4 * i + 1] /= v[4 * i + 3]; // v / w
-			// Those don't seem necessary
-			//t[4 * i + 2] /= v[4 * i + 3]; // r / w
-			//t[4 * i + 3] = 1f;  // Set q to 1
+			// Texture coordinates are stored as s/w and t/w (undone per-pixel in the rasterizer)
+			if (t != null)
+			{
+				t[4 * i + 0] *= invW[i]; // s / w
+				t[4 * i + 1] *= invW[i]; // t / w
+			}
 		}
 	}
 

--- a/src/org/recompile/freej2me/Libretro.java
+++ b/src/org/recompile/freej2me/Libretro.java
@@ -607,12 +607,16 @@ public class Libretro
 										/* Vibration duration should be set to zero to prevent constant sends of the same data, so update it here */
 										Mobile.vibrationDuration = 0;
 
-										/* Send display data to libretro */
-										for(int i=0; i<lcdData.length; i++)
+										/* Send display data to libretro. The conversion is synchronized against
+										 * flushGraphics() so a concurrent flush cannot tear the outgoing frame. */
+										synchronized (Mobile.getPlatform().getLcdFrontbuffer())
 										{
-											frameBuffer[3*i]   = (byte)((lcdData[i]>>16)&0xFF);
-											frameBuffer[3*i+1] = (byte)((lcdData[i]>>8)&0xFF);
-											frameBuffer[3*i+2] = (byte)((lcdData[i])&0xFF);
+											for(int i=0; i<lcdData.length; i++)
+											{
+												frameBuffer[3*i]   = (byte)((lcdData[i]>>16)&0xFF);
+												frameBuffer[3*i+1] = (byte)((lcdData[i]>>8)&0xFF);
+												frameBuffer[3*i+2] = (byte)((lcdData[i])&0xFF);
+											}
 										}
 
 										System.out.write(frameBuffer, 0, lcdData.length*3);

--- a/src/org/recompile/mobile/MobilePlatform.java
+++ b/src/org/recompile/mobile/MobilePlatform.java
@@ -876,7 +876,12 @@ public class MobilePlatform
 	{
 		if(!Mobile.isPaused && !appTerminated)
 		{
-			gcFrontbuffer.flushGraphics(img, x, y, width, height);
+			/* Synchronized so a frontend reading the frontbuffer (e.g. the libretro
+			 * pipe serializer) never observes a half-flushed frame (tearing). */
+			synchronized (lcdFrontbuffer)
+			{
+				gcFrontbuffer.flushGraphics(img, x, y, width, height);
+			}
 			if(postDraw != null) { postDraw.run(); postDraw = null; }
 			painter.run();
 			


### PR DESCRIPTION
## Summary

This PR fixes twelve defects in the JSR-184 (M3G) software renderer and the libretro frame path. They were diagnosed by driving the libretro core frame-by-frame with real games (Tower Bloxx Deluxe, 3D Bomberman Atomic, Bomberman 3D) and validating every change against KEmulator 1.0.3 running the exact same JARs side by side.

## Fixes

**Sprite3D & 2D/3D compositing**
1. **Implement `Sprite3D` rendering** — screen-aligned textured quads following the JSR-184 reference implementation math (`m3g_sprite.c`), with crop rectangle handling (including negative crop = flip) and alpha. Games that draw their player/props as sprites rendered nothing at all.
2. **`clear(Background)` semantics** — per JSR-184 the crop rectangle is a *sampling window* into the background image; the destination is always the full viewport. The old code used the crop as the destination rectangle, so games passing a 0x0 crop never cleared the screen (permanent sprite trails).
3. **Frame tearing** — the libretro frame serialization now synchronizes against `flushGraphics()` (`Libretro.java` / `MobilePlatform.java`).

**Geometry pipeline**
4. **Real near-plane clipping** — Sutherland–Hodgman in clip space, interpolating positions and texture coordinates; crossing triangles are split (fan-triangulated). Previously they were either dropped or exploded to huge screen coordinates after the perspective division.
5. **Clip against the camera's actual near plane** — obtained from `Camera.getProjection(params)`, instead of the depth-range near (0 by default, which left clipped vertices at `w == 0` → `1/w = Inf` and killed every crossing triangle).
6. **Non-destructive triangle-strip winding correction** — the strip detector used to swap indices *inside the game's own `IndexBuffer` array*, corrupting shared meshes cumulatively across renders. The swap is now done on local copies, compared against the previous triangle's effective (post-swap) indices, which reproduces the intended first-render behavior exactly.
7. **Scope culling** — meshes and sprites with `(node scope & camera scope) == 0` are no longer drawn.

**Rasterizer**
8. **Perspective-correct texturing** — `s/w`, `t/w` and `1/w` interpolated linearly in screen space and divided per pixel (games explicitly request it via `PolygonMode.setPerspectiveCorrectionEnable`).
9. **Texture wrapping at sampling time** — `WRAP_REPEAT` tiles, `WRAP_CLAMP` clamps to edge; out-of-range coordinates never index outside the image.
10. **Alpha test before depth write** — fully transparent fragments no longer write depth, so they don't occlude geometry drawn later (e.g. cut-out foliage drawn before the ground).
11. **Texture blending in the vertex-color path per JSR-184** — `FUNC_REPLACE` keeps the texture sample (it previously got *replaced by* the interpolated vertex color, flattening any textured mesh that also carries vertex colors — city backdrops rendered as solid silhouettes); `FUNC_MODULATE` multiplies texture and vertex color.
12. **Per-triangle flat lighting** — two-sided diffuse + ambient when the `Appearance` has a `Material` and lights are present (previously unlit).

## Before / after

Same build, same input script, same frame. Left: current master. Right: this PR.

**3D Bomberman Atomic — the player is a Sprite3D and did not render at all:**

![Atomic before/after](https://raw.githubusercontent.com/estebanrios/freej2me-plus/assets-m3g-fixes/img/atomic_before_after.png)

**Tower Bloxx Deluxe, gameplay — near-plane clipping + FUNC_REPLACE blending (city backdrop and ground were missing):**

![Tower Bloxx gameplay before/after](https://raw.githubusercontent.com/estebanrios/freej2me-plus/assets-m3g-fixes/img/towerbloxx_game_before_after.png)

**Tower Bloxx Deluxe, title screen:**

![Tower Bloxx title before/after](https://raw.githubusercontent.com/estebanrios/freej2me-plus/assets-m3g-fixes/img/towerbloxx_title_before_after.png)

**Reference comparison — KEmulator 1.0.3 running the same JAR (left) vs this PR (right):**

![KEmulator reference](https://raw.githubusercontent.com/estebanrios/freej2me-plus/assets-m3g-fixes/img/kemulator_reference.png)

## Validation

- Frame-by-frame driving of the libretro core through its stdin/stdout protocol on desktop, with scripted inputs, comparing identical frames between master and this branch.
- Cross-checked against KEmulator 1.0.3 (Swerve M3G engine) running the same JARs; transform semantics were verified with a dedicated oracle MIDlet (`postTranslate`/`postRotate`/`postScale` chains match to the float).
- Regression-tested with Tower Bloxx Deluxe, 3D Bomberman Atomic and Bomberman 3D (N70); also tested on real hardware (TrimUI Smart Pro S, aarch64) through the libretro core.
- `javac` clean build of the full source tree.

One known remaining difference vs KEmulator in Tower Bloxx Deluxe (the excavation pit + foundation slab around the drop point) is still under investigation and intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
