### PR TITLE
M3G: NPE on null PolygonMode fix

### DIFF
--- a/src/javax/microedition/m3g/Graphics3D.java
+++ b/src/javax/microedition/m3g/Graphics3D.java
@@ -688,11 +688,12 @@ public class Graphics3D
 		final float clipNear = (projType == Camera.PERSPECTIVE) ? M3GMath.max(projParams[2], 1e-4f) : 1e-4f;
 
 		// Create Triangle objects (fromVertAndTris already does culling and clipping)
+        final boolean twoSided = appearance.getPolygonMode() != null ? appearance.getPolygonMode().isTwoSidedLightingEnabled() : false;
 		final Triangle[] trisScreen = Triangle.fromVertAndTris(
 			// Position and texture vertex data
 			vertClip, texVerts,
 			// Material and shading
-			material, shadingMode, appearance.getPolygonMode().isTwoSidedLightingEnabled(),
+			material, shadingMode, twoSided,
 			// Normal data
 			eyePos, vertNorms, normalMatrix,
 			// Lights


### PR DESCRIPTION
According to jsr-184 PolygonMode can be null, default CULL_BACK https://nikita36078.github.io/J2ME_Docs/docs/jsr184/javax/microedition/m3g/Appearance.html
 "All components of a newly created Appearance object are initialized to null. It is completely legal for any or all of the components to be null even when rendering. The behavior when each of the components is null is as follows:

If a Texture2D is null, the corresponding texturing unit is disabled. If the PolygonMode is null, default values are used. If the CompositingMode is null, default values are used. If the Material is null, lighting is disabled.
If the Fog is null, fogging is disabled. "
Before PR:
<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/ce0fb0ba-dbf7-4464-8ee4-2e2ded11f7c6" />
after PR:
<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/ab65a6be-3973-4db8-a601-3b88779fad86" />
