### PR TITLE
M3G: preserve opaque alpha during texture modulation.

### DIFF
--- a/src/javax/microedition/m3g/Graphics3D.java
+++ b/src/javax/microedition/m3g/Graphics3D.java
@@ -1628,21 +1628,36 @@ public class Graphics3D
 				return bg;
 			}
 
-			case Texture2D.FUNC_MODULATE:
-			{
-				int fR = (bg >> 16) & 0xFF, fG = (bg >> 8) & 0xFF, fB = bg & 0xFF, fA = bg >>> 24;
-				int tR = (fg >> 16) & 0xFF, tG = (fg >> 8) & 0xFF, tB = fg & 0xFF, tA = fg >>> 24;
+            case Texture2D.FUNC_MODULATE:
+            {
+                int fR = (bg >> 16) & 0xFF, fG = (bg >> 8) & 0xFF, fB = bg & 0xFF, fA = bg >>> 24;
+                int tR = (fg >> 16) & 0xFF, tG = (fg >> 8) & 0xFF, tB = fg & 0xFF, tA = fg >>> 24;
 
-				int outR = (texFormat == Image2D.ALPHA) ? fR : (fR * tR) >> 8;
-				int outG = (texFormat == Image2D.ALPHA) ? fG : (fG * tG) >> 8;
-				int outB = (texFormat == Image2D.ALPHA) ? fB : (fB * tB) >> 8;
+                int outR, outG, outB, outA;
 
-				boolean hasAlpha = (texFormat == Image2D.ALPHA ||
-					texFormat == Image2D.LUMINANCE_ALPHA || texFormat == Image2D.RGBA);
-				int outA = hasAlpha ? (fA * tA) >> 8 : fA;
+                if (texFormat == Image2D.ALPHA)
+                {
+                    outR = fR;
+                    outG = fG;
+                    outB = fB;
+                }
+                else
+                {
+                    int pR = fR * tR + 1; outR = (pR + (pR >> 8)) >> 8;
+                    int pG = fG * tG + 1; outG = (pG + (pG >> 8)) >> 8;
+                    int pB = fB * tB + 1; outB = (pB + (pB >> 8)) >> 8;
+                }
 
-				return (outA << 24) | (outR << 16) | (outG << 8) | outB;
-			}
+                if (texFormat == Image2D.ALPHA || texFormat == Image2D.LUMINANCE_ALPHA
+                        || texFormat == Image2D.RGBA)
+                {
+                    int pA = fA * tA + 1;
+                    outA = (pA + (pA >> 8)) >> 8;
+                }
+                else { outA = fA; }
+
+                return (outA << 24) | (outR << 16) | (outG << 8) | outB;
+            }
 
 			case Texture2D.FUNC_REPLACE:
 				// RGB & LUMINANCE don't carry an alpha channel, so we use the bg alpha


### PR DESCRIPTION
Stalker mobile has their custom 3d mesh format Z1 alongside with M3G. Also stalker mobile uses Texture2D.FUNC_MODULATE together with an alpha threshold of 1.0 for most Z1 submeshes, which caused the entire models to become invisible.

The fix introduces an exact rounded division by 255, ensuring that full intensity and full opacity remain 255.

Before PR:
<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/c6a86d4c-b9db-45ff-935b-cc1b3da01138" />
After PR:
<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/a39bf36b-08fc-4672-ac46-4120b646b63a" />
