### PR TITLE
m3g: add a second Newton-Rapshon step; fix cumulative rotation-matrix distortion from postRotate/postRotateQuat

### DIFF
--- a/src/javax/microedition/m3g/Camera.java
+++ b/src/javax/microedition/m3g/Camera.java
@@ -82,9 +82,11 @@ public class Camera extends Node
 			 * This cache is re-set to null by `setParallel` and `setPerspective`.
 			 */
 			if (dirtyMatrix) { this.computeMatrix(); }
+
+            /* Copies the current projection matrix to the given transform, and returns the current projection mode. */
+            transform.set(this.projMatrix);
 		}
-		/* Copies the current projection matrix to the given transform, and returns the current projection mode. */
-		transform.set(this.projMatrix);
+        /* As per JSR-184, a null transform is allowed and only the projection type is returned. */
 		return this.projMode;
 	}
 

--- a/src/javax/microedition/m3g/M3GMath.java
+++ b/src/javax/microedition/m3g/M3GMath.java
@@ -70,7 +70,9 @@ public class M3GMath
 		int i = Float.floatToRawIntBits(x);
 		i = 0x5f3759df - (i >> 1);
 		x = Float.intBitsToFloat(i);
-		return x * (1.5f - (xhalf * x * x));
+        x = x * (1.5f - (xhalf * x * x));
+        x = x * (1.5f - (xhalf * x * x));
+        return x;
 	}
 
 	public static float sqrt(float x)

--- a/src/javax/microedition/m3g/Transform.java
+++ b/src/javax/microedition/m3g/Transform.java
@@ -345,17 +345,19 @@ public class Transform
 		// Angle or axis length as zero means no/invalid rotation. Return right away
 		if (angle == 0.0f || axisLen < M3GMath.EPSILON) { return; }
 
-		if (angle == 0) { return; }
-
 		float rad = M3GMath.toRadians(angle);
 		float s = M3GMath.sin(rad);
 		float c = M3GMath.cos(rad);
 		float d = 1.0f - c;
 
-		float l = M3GMath.sqrt(axisLen);
-		float x = ax / l;
-		float y = ay / l;
-		float z = az / l;
+        float x = ax, y = ay, z = az;
+        if (M3GMath.abs(axisLen - 1.0f) > 1.0e-6f)
+        {
+            final float invL = M3GMath.fastReciprocal(M3GMath.sqrt(axisLen));
+            x *= invL;
+            y *= invL;
+            z *= invL;
+        }
 
 		manipulationMatrix[0] = x*x*d + c;   manipulationMatrix[1] = y*x*d - z*s; manipulationMatrix[2] = z*x*d + y*s;
 		manipulationMatrix[4] = x*y*d + z*s; manipulationMatrix[5] = y*y*d + c;   manipulationMatrix[6] = z*y*d - x*s;
@@ -370,11 +372,11 @@ public class Transform
 			throw new IllegalArgumentException("Cannot rotate when all quaternion components are zero.");
 		}
 
-		float l = M3GMath.sqrt((qx * qx) + (qy * qy) + (qz * qz) + (qw * qw));
-		float x = qx / l;
-		float y = qy / l;
-		float z = qz / l;
-		float w = qw / l;
+        final float invL = M3GMath.fastReciprocal(M3GMath.sqrt((qx * qx) + (qy * qy) + (qz * qz) + (qw * qw)));
+        float x = qx * invL;
+        float y = qy * invL;
+        float z = qz * invL;
+        float w = qw * invL;
 
 		manipulationMatrix[0] = 1 - 2*y*y - 2*z*z;
 		manipulationMatrix[1] = 2*x*y - 2*z*w;


### PR DESCRIPTION
Games commonly orbit the camera by chaining postRotate(a)/postRotate(-a) on the same node as exact inverses, without ever resetting the rotate matrix. computeRotationMatrix() normalized the axis via invSqrt(), whose single Newton-Raphson step carries ~0.17% error (sqrt(1.0f) == 0.9983), so every generated matrix embedded a slight non-uniform scale. That error accumulated on each key press, visibly squashing/stretching the scene after a couple of camera orbits

- invSqrt(): add a second Newton-Raphson step, dropping max relative error from ~1.7e-03 to ~4e-06. Callers get more accurate skinning and lighting normals for one extra multiply-add sequence. @AShiningRay did actually
- computeRotationMatrix(): skip normalization for unit axes (the overwhelmingly common case, and bit-exact for repeated orbits), and normalize non-unit axes with fastReciprocal(sqrt()) - reciprocal multiplication instead of three divides. Drops the redundant duplicate angle check as well.
- computeRotationQuatMatrix(): same reciprocal-multiplication change.
- Camera.getProjection(Transform): accept a null transform per JSR-184 instead of throwing NPE (only the projection type is returned).