### PR TITLE
M3G: Grow the depth buffer when setViewport enlarges the viewport

### DIFF
--- a/src/javax/microedition/m3g/Graphics3D.java
+++ b/src/javax/microedition/m3g/Graphics3D.java
@@ -1071,6 +1071,21 @@ public class Graphics3D
 		this.viewy = y;
 		this.vieww = width;
 		this.viewh = height;
+
+		/*
+		 * The depth buffer is indexed in viewport-relative coordinates (y * vieww + x),
+		 * and bindTarget sizes it for the viewport in effect at bind time. JSR-184 allows
+		 * setViewport to be called at any point between bind and release with a viewport
+		 * larger than the bind-time one (e.g. binding with a small clip rect, then setting
+		 * a fullscreen viewport), so grow the buffer here or the rasterizer will index
+		 * out of bounds. Its previous contents are laid out for the old width and thus
+		 * meaningless for the new viewport either way, so reset it to the far plane.
+		 */
+		if (this.depthBuffer != null && this.depthBuffer.length < width * height)
+		{
+			this.depthBuffer = new short[width * height];
+			Arrays.fill(this.depthBuffer, (short) M3GMath.round(this.far * 32767.0f));
+		}
 	}
 
 


### PR DESCRIPTION
bindTarget sizes the depth buffer for the viewport in effect at bind time (the Graphics clip rect for Graphics targets). JSR-184 allows setViewport to be called at any point afterwards with a larger viewport — e.g. binding with a quarter-screen clip and then setting a fullscreen viewport, as the classic RenderTarget demo does for its four-quadrant pass. The rasterizer indexes depth as y * vieww + x, so this overran the bind-time buffer and every frame died with an ArrayIndexOutOfBoundsException before drawing anything.

Reallocate the buffer in setViewport when the new viewport needs more space, resetting it to the far plane (its old contents are laid out for the previous width and are meaningless for the new viewport).
nokia rendertarget demo
before pr :
<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/0086d953-f0e9-419d-8009-940066de0040" />
after:
<img width="242" height="372" alt="image" src="https://github.com/user-attachments/assets/d1e5d598-7d02-402c-9057-c97e87d0585c" />
