### PR TITLE
M3G: Treat all-zero alpha in paletted RGBA textures as opaque

### DIFF
--- a/src/javax/microedition/m3g/Image2D.java
+++ b/src/javax/microedition/m3g/Image2D.java
@@ -113,6 +113,26 @@ public class Image2D extends Object3D
 		this.width = w;
 		this.height = h;
 
+		/*
+		 * Some exporters (e.g. Firemint's, seen in NFS Most Wanted) write RGBA palettes
+		 * where the alpha byte of EVERY entry is 0 - a leftover "reserved" byte rather
+		 * than real transparency data. Taken literally, every texel would be fully
+		 * transparent and the whole mesh invisible, which is clearly never intended
+		 * (a fully-transparent texture is useless). Detect that degenerate case and
+		 * treat such palettes as fully opaque. Palettes with any non-zero alpha entry
+		 * (i.e. real cutout/translucency data) are left untouched.
+		 * TODO: A hack, might cause issues. Should be revisited
+		 */
+		boolean forceOpaque = false;
+		if (this.format == RGBA)
+		{
+			forceOpaque = true;
+			for (int p = 3; p < palette.length; p += 4)
+			{
+				if (palette[p] != 0) { forceOpaque = false; break; }
+			}
+		}
+
 		// We now start to copy the received "image" comprised of palette indices, as well as the palette colors themselves.
 		this.image = new byte[image.length * this.bpp];
 
@@ -127,6 +147,7 @@ public class Image2D extends Object3D
 			int offset = i * this.bpp;
 			// The pallete will be 256 entries multiplied by the format's amount of bytes per pixel
 			for (int k = 0; k < bpp; k++) { this.image[offset + k] = palette[pIdx + k]; }
+			if (forceOpaque) { this.image[offset + 3] = (byte) 0xFF; }
 		}
 	}
 


### PR DESCRIPTION
Some exporters (Firemint's, as seen in NFS Most Wanted) emit RGBA palettes where the alpha byte of every entry is 0 - a leftover 'reserved' byte rather than transparency data. Taken literally, every texel of such a texture is fully transparent, so the rasterizer's zero-alpha fragment discard made the game's whole menu background and track geometry invisible (only the car rendered, since its textures are built at runtime from PNGs as opaque RGB Image2Ds).

A texture whose every texel is fully transparent can never be the intent, so detect the degenerate all-zero-alpha palette at load time and force those pixels opaque. Palettes containing any non-zero alpha entry (real cutout/translucency data, e.g. Speed Spirit's vegetation) are untouched, and the rasterizer's alpha handling is not changed at all, so this cannot regress alpha-blended rendering.

This replaces the earlier attempt that skipped the zero-alpha discard under REPLACE compositing, which broke Speed Spirit's cutouts.