### PR TITLE
M3G: Group.pick(camera): normalize W before leaving camera space

### DIFF
--- a/src/javax/microedition/m3g/Group.java
+++ b/src/javax/microedition/m3g/Group.java
@@ -204,6 +204,14 @@ public class Group extends Node {
             cameraPoints[offset]     *= invW;
             cameraPoints[offset + 1] *= invW;
             cameraPoints[offset + 2] *= invW;
+
+            // The W component must be normalized along with x/y/z: these are
+            // points (not directions), and the camera-to-group transform below
+            // scales its translation column by W. Leaving the post-projection
+            // W here would shift the ray origin by (W - 1) times the camera
+            // position, breaking picking whenever the camera is not at the
+            // scene origin.
+            cameraPoints[offset + 3] = 1.0f;
         }
 
         if (!camera.getTransformTo(this, t2))


### PR DESCRIPTION
Fixes elimination of bots in Micro Counter Strike and skeletons in Golden Warrior 3D
The camera-variant pick() divided the unprojected near/far points by W only for x/y/z, leaving the homogeneous W untouched (typically far/near times larger than 1 after an inverse perspective projection). The subsequent camera-to-group transform scales its translation column by that leftover W, so the pick ray origin was shifted by (W - 1) times the camera translation. With any camera away from the scene origin the ray missed everything it was aimed at (e.g. shooting at characters via world.pick() never registered hits). The direction was similarly skewed since both endpoints carried different residual Ws.

Set W = 1 after the perspective division, matching the JSR-184 implementation guidelines (p = Pc / w with w = 1 afterwards). Verified numerically: ray origin/direction now match the analytic unprojection exactly; the flat-ray variant is unaffected.