### PR TITLE
M3G: Loader: fix sign extension and channel order in readRGB/readRGBA

### DIFF
--- a/src/javax/microedition/m3g/Loader.java
+++ b/src/javax/microedition/m3g/Loader.java
@@ -979,24 +979,35 @@ public class Loader
 
 	private int readRGB() throws IOException
 	{
-		byte r = dis.readByte();
-		byte g = dis.readByte();
-		byte b = dis.readByte();
-		bytesRead += 3;
+		/*
+		 * Color components must be read as UNSIGNED bytes. Reading them as
+		 * signed bytes sign-extends any component above 127 across the whole
+		 * int, smearing 0xFF over every higher channel (e.g. specular
+		 * (229,229,229) became (255,255,229)).
+		 */
+		int r = readByte();
+		int g = readByte();
+		int b = readByte();
 
 		return (r << 16) | (g << 8) | b;
 	}
 
-	// Reads RGBA, returns ARGB for methods that use it (they expect ARGB)
+	// Reads RGBA from the file, returns ARGB for methods that use it (they expect ARGB)
 	private int readRGBA() throws IOException
 	{
-		byte r = dis.readByte();
-		byte g = dis.readByte();
-		byte b = dis.readByte();
-		byte a = dis.readByte();
-		bytesRead += 4;
+		/*
+		 * Same unsigned handling as readRGB. Additionally, the components
+		 * must be packed as ARGB: the old RGBA packing (alpha in the low
+		 * byte), combined with the sign extension, turned e.g. a deliberately
+		 * invisible material (alpha=0, used by games for hit-flash meshes
+		 * faded in via an ALPHA animation track) into a fully opaque one.
+		 */
+		int r = readByte();
+		int g = readByte();
+		int b = readByte();
+		int a = readByte();
 
-		return a | (r << 24) | (g << 16) | (b << 8);
+		return (a << 24) | (r << 16) | (g << 8) | b;
 	}
 
 	private float readFloat() throws IOException


### PR DESCRIPTION
readRGB()/readRGBA() read color components as SIGNED bytes, so any channel above 127 sign-extended over the whole int and smeared 0xFF onto every higher channel. readRGBA() additionally packed the result as RGBA (alpha in the low byte) while all of its callers - Material diffuse, Background color, VertexBuffer default color - expect ARGB.

Combined effect: a diffuse color like (212,143,69,255) loaded as pure white, and deliberately invisible materials (diffuse alpha = 0) loaded as fully opaque. Games commonly ship hit-flash / damage-indicator meshes with an alpha=0 material that is faded in through an ALPHA animation track on hit (e.g. Golden Warrior's skeletons); those were visible from the very first frame instead of only flashing on hit.

Read the components unsigned and pack ARGB.

Before PR:

<img width="227" height="349" alt="image" src="https://github.com/user-attachments/assets/d0345e0d-ee27-4b64-baaa-f5772426248c" />
<img width="228" height="357" alt="image" src="https://github.com/user-attachments/assets/12beaa38-c1d0-4585-9604-dcbb6185e341" />

After PR:

<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/1875f9b6-9ad6-4b76-bcd5-60fba2a050d7" />
<img width="232" height="362" alt="image" src="https://github.com/user-attachments/assets/fea49fa1-3c31-4aed-b6e1-fd13f592ee0f" />
