### PR TITLE
M3G: Fix Node alignment (billboards rendered with wrong orientation).

### DIFF
--- a/src/javax/microedition/m3g/M3GMath.java
+++ b/src/javax/microedition/m3g/M3GMath.java
@@ -191,6 +191,26 @@ public class M3GMath
 	// [1] = y
 	// [2] = z
 	// [3] = w
+	// Converts an (angleDegrees, ax, ay, az) angle-axis rotation, as returned by
+	// Transformable.getOrientation, into a unit quaternion.
+	public static final float[] angleAxisToQuat(float angleDeg, float ax, float ay, float az)
+	{
+		float[] quat = new float[4];
+		float axisLenSq = (ax * ax) + (ay * ay) + (az * az);
+
+		if (axisLenSq < EPSILON) { quat[3] = 1.0f; return quat; }
+
+		float halfAngle = toRadians(angleDeg) * 0.5f;
+		float s = sin(halfAngle) * fastReciprocal(sqrt(axisLenSq));
+
+		quat[0] = ax * s;
+		quat[1] = ay * s;
+		quat[2] = az * s;
+		quat[3] = cos(halfAngle);
+
+		return quat;
+	}
+
 	public static final void mulQuat(float[] q1, float[] q2, float[] result)
 	{
 		result[0] = q1[3] * q2[0] + q1[0] * q2[3] + q1[1] * q2[2] - q1[2] * q2[1]; // x
@@ -252,24 +272,42 @@ public class M3GMath
 		orig[3] = s0 * q0[3] + s1 * q1w;
 	}
 
+	// Returns the shortest-arc rotation taking srcAxis to targetAxis, as a unit quaternion.
+	// Uses the standard "half-way" construction: q = (srcAxis x targetAxis, |srcAxis||targetAxis| + dot),
+	// normalized. Note that the cross product already carries a sin(angle) factor, so scaling it
+	// by sin(angle/2) (as done previously) yields a non-unit quaternion and a wrong rotation.
 	public static final float[] setQuatRotation(float[] srcAxis, float[] targetAxis)
 	{
 		float[] rot = new float[4];
-		float[] cross = new float[3];
 		float dot = srcAxis[0] * targetAxis[0] + srcAxis[1] * targetAxis[1] + srcAxis[2] * targetAxis[2];
 
-		cross[0] = srcAxis[1] * targetAxis[2] - srcAxis[2] * targetAxis[1];
-		cross[1] = srcAxis[2] * targetAxis[0] - srcAxis[0] * targetAxis[2];
-		cross[2] = srcAxis[0] * targetAxis[1] - srcAxis[1] * targetAxis[0];
+		rot[0] = srcAxis[1] * targetAxis[2] - srcAxis[2] * targetAxis[1]; // x
+		rot[1] = srcAxis[2] * targetAxis[0] - srcAxis[0] * targetAxis[2]; // y
+		rot[2] = srcAxis[0] * targetAxis[1] - srcAxis[1] * targetAxis[0]; // z
 
-		float angle = acos(dot);
-		float sinHalfAngle = sin(angle / 2);
+		float srcLenSq = srcAxis[0] * srcAxis[0] + srcAxis[1] * srcAxis[1] + srcAxis[2] * srcAxis[2];
+		float targetLenSq = targetAxis[0] * targetAxis[0] + targetAxis[1] * targetAxis[1] + targetAxis[2] * targetAxis[2];
 
-		rot[0] = cross[0] * sinHalfAngle; // x
-		rot[1] = cross[1] * sinHalfAngle; // y
-		rot[2] = cross[2] * sinHalfAngle; // z
-		rot[3] = cos(angle / 2); // w
+		// Degenerate axes carry no direction. Return the identity rotation, as per
+		// JSR-184 (coincident target vector maps to the identity rotation).
+		if (srcLenSq < EPSILON || targetLenSq < EPSILON)
+		{
+			rot[0] = 0.0f; rot[1] = 0.0f; rot[2] = 0.0f; rot[3] = 1.0f;
+			return rot;
+		}
 
-		return rot;
+		rot[3] = sqrt(srcLenSq * targetLenSq) + dot; // w
+
+		float normSq = rot[0] * rot[0] + rot[1] * rot[1] + rot[2] * rot[2] + rot[3] * rot[3];
+		if (normSq < EPSILON)
+		{
+			// Vectors are (nearly) opposite, the rotation is ambiguous. As per JSR-184,
+			// pick a deterministic result: 180 degrees about any axis perpendicular to srcAxis.
+			if (abs(srcAxis[0]) > abs(srcAxis[2])) { rot[0] = -srcAxis[1]; rot[1] = srcAxis[0]; rot[2] = 0.0f; }
+			else                                   { rot[0] = 0.0f; rot[1] = -srcAxis[2]; rot[2] = srcAxis[1]; }
+			rot[3] = 0.0f;
+		}
+
+		return normalizeQuat(rot);
 	}
 }

--- a/src/javax/microedition/m3g/Node.java
+++ b/src/javax/microedition/m3g/Node.java
@@ -62,7 +62,7 @@ public abstract class Node extends Transformable
 
 	public final void align(Node reference)
 	{
-		Mobile.log(Mobile.LOG_WARNING, Node.class.getPackage().getName() + "." + Node.class.getSimpleName() + ": " + "Node Alignment requested (untested)");
+		Mobile.log(Mobile.LOG_DEBUG, Node.class.getPackage().getName() + "." + Node.class.getSimpleName() + ": " + "Node Alignment requested");
 		if (reference != null && (this.getRootNode() != reference.getRootNode())) { throw new IllegalArgumentException(); }
 
 		doAlign(reference == null ? this : reference);
@@ -106,14 +106,31 @@ public abstract class Node extends Transformable
 
 		getOrientation(orientation);
 
+		/*
+		 * As per JSR-184, the alignment rotation is computed in the reference frame
+		 * defined by the T component of this node's transformation alone. Axis targets
+		 * are transformed as vectors and are unaffected, but ORIGIN targets are
+		 * transformed as points and must be made relative to this node's position,
+		 * so premultiply the target-to-parent transform by T^-1 (which only offsets
+		 * its translation column).
+		 */
 		float[] translation = new float[3];
 		getTranslation(translation);
-		transform.postTranslate(transformMatrix[12], transformMatrix[13], transformMatrix[14]);
+		transform.get(transformMatrix);
+		transformMatrix[3] -= translation[0];
+		transformMatrix[7] -= translation[1];
+		transformMatrix[11] -= translation[2];
+		transform.set(transformMatrix);
 
 		if (constraint != NONE)
 		{
-			float[] rot = new float[]{ orientation[0], orientation[1], orientation[2], -orientation[3] };
-			transform.preRotate(rot[0], rot[1], rot[2], rot[3]);
+			/*
+			 * Constrained (Y axis) alignment: as per JSR-184, the Y target must be
+			 * expressed in the frame resulting from the Z rotation computed just
+			 * before, i.e. tY' = Rz^-1 * tY. The inverse rotation is obtained by
+			 * negating the angle, not the axis' Z component.
+			 */
+			transform.preRotate(-orientation[0], orientation[1], orientation[2], orientation[3]);
 		}
 
 		transform.get(transformMatrix);
@@ -144,16 +161,19 @@ public abstract class Node extends Transformable
 
 		if (constraint != NONE)
 		{
+			/* Final alignment rotation as per JSR-184: A = Rz * Ry. */
+			float[] quatZ = M3GMath.angleAxisToQuat(orientation[0], orientation[1], orientation[2], orientation[3]);
 			float[] newOrientation = new float[4];
-			M3GMath.mulQuat(orientation, rot, newOrientation);
-			System.arraycopy(newOrientation, 0, orientation, 0, 4);
-		}
-		else
-		{
-			System.arraycopy(rot, 0, orientation, 0, 4);
+			M3GMath.mulQuat(quatZ, rot, newOrientation);
+			rot = newOrientation;
 		}
 
-		setOrientation(orientation[0], orientation[1], orientation[2], orientation[3]);
+		/*
+		 * As per JSR-184, align() overwrites the R component of the node transform.
+		 * Note that rot is a quaternion, NOT the (angleDegrees, ax, ay, az) tuple
+		 * that setOrientation expects, so it must be applied as a quaternion.
+		 */
+		setOrientationQuat(rot[0], rot[1], rot[2], rot[3]);
 		return true;
 	}
 

--- a/src/javax/microedition/m3g/Transformable.java
+++ b/src/javax/microedition/m3g/Transformable.java
@@ -134,6 +134,16 @@ public abstract class Transformable extends Object3D
 		invalidateTransformable();
 	}
 
+	// Internal helper: sets the R component directly from a quaternion,
+	// avoiding a lossy quaternion -> angle-axis -> matrix round trip.
+	// Used by Node alignment, where the alignment rotation is a quaternion.
+	void setOrientationQuat(float qx, float qy, float qz, float qw)
+	{
+		this.rotate.setIdentity();
+		this.rotate.preRotateQuat(qx, qy, qz, qw);
+		invalidateTransformable();
+	}
+
 	public void setScale(float sx, float sy, float sz)
 	{
 		this.scale.setIdentity();


### PR DESCRIPTION
Node.align()/computeAlignment() produced incorrect rotations, visible e.g. in MicroCounter-Strike where wall impact sprites (Z_AXIS-aligned quads) faced random directions. Per the JSR-184 Node spec, the alignment rotation A = Rz*Ry must take the local Z axis onto the target vector via the shortest rotation, computed in the frame defined by the node's T component alone.

Fixes:
- M3GMath.setQuatRotation built a non-unit quaternion: the unnormalized cross product (which already carries a sin(angle) factor) was scaled by sin(angle/2), so the rotation missed the target for any angle other than 90 degrees. Now uses the standard shortest-arc construction q = normalize(cross(src, t), |src||t| + dot), with deterministic handling of the coincident (identity) and opposite (180-degree) cases as required by the spec.
- computeAlignmentRotation passed the resulting quaternion straight to setOrientation(), which expects (angleDegrees, ax, ay, az); the quat's X component was interpreted as an angle in degrees. Added Transformable.setOrientationQuat() and applied the rotation as a quaternion.
- The constrained (Y with Z constraint) path multiplied the angle-axis tuple as if it were a quaternion, and inverted Rz by negating the axis Z instead of the angle. Now converts angle-axis to a quaternion via new M3GMath.angleAxisToQuat() before composing A = Rz*Ry, and inverts by negating the angle.
- The ORIGIN-target offset was a no-op: postTranslate() was fed values read from a still-zeroed matrix array. ORIGIN targets transform as points and must be made relative to the aligned node's position, so the translation column of the target-to-parent transform is now offset by -T.

Before:
<img width="479" height="638" alt="image" src="https://github.com/user-attachments/assets/ebc192b1-6da7-4230-8788-178ee435ea6b" />

After:
<img width="479" height="637" alt="image" src="https://github.com/user-attachments/assets/cecf478d-7bb0-49a5-a4b2-cfd7a8615b26" />
